### PR TITLE
Feature/allow delete from input prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ function(tag, currPos, newPos) {
 Optional boolean param to control whether the text-input should be autofocused on mount.
 
 ```js
-<ReacTags
+<ReactTags
     autofocus={false}
-    ...>
+    ...>        
 ```
 
 <a name="allowDeleteFromEmptyInput"></a>

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Otherwise, you can simply import along with the backend itself (as shown above).
 - [`handleDelete`](#handleDeleteOption)
 - [`handleDrag`](#handleDragOption)
 - [`autofocus`](#autofocus)
+- [`allowDeleteFromEmptyInput`](#allowDeleteFromEmptyInput)
 
 <a name="tagsOption"></a>
 ##### tags (optional)
@@ -177,6 +178,16 @@ Optional boolean param to control whether the text-input should be autofocused o
     ...>
 ```
 
+<a name="allowDeleteFromEmptyInput"></a>
+##### allowDeleteFromEmptyInput (optional)
+Optional boolean param to control whether tags should be deleted when the 'Delete' key is pressed in an empty Input Box.
+
+```js
+<ReactTags
+    allowDeleteFromEmptyInput={false}
+    ...>
+```
+    
 ### Styling
 `<ReactTags>` does not come up with any styles. However, it is very easy to customize the look of the component the way you want it. The component provides the following classes with which you can style - 
 

--- a/dist-modules/reactTags.js
+++ b/dist-modules/reactTags.js
@@ -31,14 +31,16 @@ var ReactTags = React.createClass({
         autofocus: React.PropTypes.bool,
         handleDelete: React.PropTypes.func.isRequired,
         handleAddition: React.PropTypes.func.isRequired,
-        handleDrag: React.PropTypes.func.isRequired
+        handleDrag: React.PropTypes.func.isRequired,
+        allowDeleteFromEmptyInput: React.PropTypes.bool
     },
     getDefaultProps: function getDefaultProps() {
         return {
             placeholder: 'Add new tag',
             tags: [],
             suggestions: [],
-            autofocus: true
+            autofocus: true,
+            allowDeleteFromEmptyInput: true
         };
     },
     componentDidMount: function componentDidMount() {
@@ -95,7 +97,7 @@ var ReactTags = React.createClass({
         }
 
         // when backspace key is pressed and query is blank, delete tag
-        if (e.keyCode === Keys.BACKSPACE && query == '') {
+        if (e.keyCode === Keys.BACKSPACE && query == '' && this.props.allowDeleteFromEmptyInput) {
             //
             this.handleDelete(this.props.tags.length - 1);
         }

--- a/lib/reactTags.js
+++ b/lib/reactTags.js
@@ -23,14 +23,16 @@ var ReactTags = React.createClass({
         autofocus: React.PropTypes.bool,
         handleDelete: React.PropTypes.func.isRequired,
         handleAddition: React.PropTypes.func.isRequired,
-        handleDrag: React.PropTypes.func.isRequired
+        handleDrag: React.PropTypes.func.isRequired,
+        allowDeleteFromEmptyInput: React.PropTypes.bool
     },
     getDefaultProps: function() {
         return {
             placeholder: 'Add new tag',
             tags: [],
             suggestions: [],
-            autofocus: true
+            autofocus: true,
+            allowDeleteFromEmptyInput: true
         }
     },
     componentDidMount: function() {
@@ -84,7 +86,7 @@ var ReactTags = React.createClass({
         }
 
         // when backspace key is pressed and query is blank, delete tag
-        if (e.keyCode === Keys.BACKSPACE && query == "") { //
+        if (e.keyCode === Keys.BACKSPACE && query == "" && this.props.allowDeleteFromEmptyInput) { //
             this.handleDelete(this.props.tags.length - 1);
         }
 


### PR DESCRIPTION
PR for Issue: #16 

Adding new optional prop `allowDeleteFromEmptyInput` (default: `true`) to toggle whether or not tags should be deleted when the 'Delete' key is pressed on an empty Input

This is useful when tags are not inline, but 'stacked'

![screenshot 2015-09-17 10 19 08](https://cloud.githubusercontent.com/assets/332474/9999456/5a922966-604b-11e5-88bb-79e788bb03ca.png)
