### PR TITLE
use node_modules/.bin/babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress --colors --port 8090",
-    "build": "webpack -p && ./node_modules/babel/bin/babel/index.js ./lib --out-dir dist-modules"
+    "build": "webpack -p && ./node_modules/.bin/babel ./lib --out-dir dist-modules"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Using the node_modules .bin is more future proof. If the babel project
were to rename or change their file structure the build script would
fail.

As a matter of fact they did this already.
`node_modules/babel/bin/index.js` has been renamed to `babel.js`