### PR TITLE
Allow to specify any keys as tag delimeters

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Otherwise, you can simply import along with the backend itself (as shown above).
 - [`autofocus`](#autofocus)
 - [`allowDeleteFromEmptyInput`](#allowDeleteFromEmptyInput)
 - [`handleInputChange`](#handleInputChange)
+- [`minQueryLength`](#minQueryLength)
 
 <a name="tagsOption"></a>
 ##### tags (optional)
@@ -205,6 +206,11 @@ Optional event handler for input onChange
     ...>
 ```
     
+<a name="minQueryLength"></a>
+##### minQueryLength (optional)
+How many characters are needed for suggestions to appear (default: 2).
+
+
 ### Styling
 `<ReactTags>` does not come up with any styles. However, it is very easy to customize the look of the component the way you want it. The component provides the following classes with which you can style - 
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Otherwise, you can simply import along with the backend itself (as shown above).
 
 - [`tags`](#tagsOption)
 - [`suggestions`](#suggestionsOption)
+- [`delimeters`](#delimeters)
 - [`placeholder`](#placeholderOption)
 - [`labelField`](#labelFieldOption)
 - [`handleAddition`](#handleAdditionOption)
@@ -118,6 +119,11 @@ An array of suggestions that are used as basis for showing suggestions. At the m
 ```js
 var suggestions = ["mango", "pineapple", "orange", "pear"];
 ```
+
+<a name="delimeters"></a>
+##### delimeters (optional)
+Specifies which characters should terminate tags input (default: enter and tab). A list of character codes.
+
 
 <a name="placeholderOption"></a>
 ##### placeholder (optional)

--- a/dist-modules/reactTags.js
+++ b/dist-modules/reactTags.js
@@ -29,6 +29,7 @@ var ReactTags = React.createClass({
         placeholder: React.PropTypes.string,
         labelField: React.PropTypes.string,
         suggestions: React.PropTypes.array,
+        delimeters: React.PropTypes.array,
         autofocus: React.PropTypes.bool,
         inline: React.PropTypes.bool,
         handleDelete: React.PropTypes.func.isRequired,
@@ -43,6 +44,7 @@ var ReactTags = React.createClass({
             placeholder: 'Add new tag',
             tags: [],
             suggestions: [],
+            delimeters: [Keys.ENTER, Keys.TAB],
             autofocus: true,
             inline: true,
             allowDeleteFromEmptyInput: true,
@@ -109,18 +111,21 @@ var ReactTags = React.createClass({
             });
         }
 
-        // when enter or tab is pressed add query to tags
-        if ((e.keyCode === Keys.ENTER || e.keyCode === Keys.TAB) && query != "") {
+        // When one of the terminating keys is pressed, add current query to the tags.
+        // If no text is typed in so far, ignore the action - so we don't end up with a terminating
+        // character typed in.
+        if (this.props.delimeters.indexOf(e.keyCode) !== -1) {
             e.preventDefault();
-            if (this.state.selectionMode) {
-                query = this.state.suggestions[this.state.selectedIndex];
+            if (query !== "") {
+                if (this.state.selectionMode) {
+                    query = this.state.suggestions[this.state.selectedIndex];
+                }
+                this.addTag(query);
             }
-            this.addTag(query);
         }
 
         // when backspace key is pressed and query is blank, delete tag
         if (e.keyCode === Keys.BACKSPACE && query == "" && this.props.allowDeleteFromEmptyInput) {
-            //
             this.handleDelete(this.props.tags.length - 1);
         }
 
@@ -242,5 +247,6 @@ var ReactTags = React.createClass({
 
 module.exports = {
     WithContext: DragDropContext(HTML5Backend)(ReactTags),
-    WithOutContext: ReactTags
+    WithOutContext: ReactTags,
+    Keys: Keys
 };

--- a/lib/reactTags.js
+++ b/lib/reactTags.js
@@ -21,6 +21,7 @@ var ReactTags = React.createClass({
         placeholder: React.PropTypes.string,
         labelField: React.PropTypes.string,
         suggestions: React.PropTypes.array,
+        delimeters: React.PropTypes.array,
         autofocus: React.PropTypes.bool,
         inline: React.PropTypes.bool,
         handleDelete: React.PropTypes.func.isRequired,
@@ -35,6 +36,7 @@ var ReactTags = React.createClass({
             placeholder: 'Add new tag',
             tags: [],
             suggestions: [],
+            delimeters: [Keys.ENTER, Keys.TAB],
             autofocus: true,
             inline: true,
             allowDeleteFromEmptyInput: true,
@@ -96,17 +98,21 @@ var ReactTags = React.createClass({
             });
         }
 
-        // when enter or tab is pressed add query to tags
-        if ((e.keyCode === Keys.ENTER || e.keyCode === Keys.TAB) && query != "") {
+        // When one of the terminating keys is pressed, add current query to the tags.
+        // If no text is typed in so far, ignore the action - so we don't end up with a terminating
+        // character typed in.
+        if (this.props.delimeters.indexOf(e.keyCode) !== -1) {
             e.preventDefault();
-            if (this.state.selectionMode) {
-                query = this.state.suggestions[this.state.selectedIndex];
+            if (query !== "") {
+                if (this.state.selectionMode) {
+                    query = this.state.suggestions[this.state.selectedIndex];
+                }
+                this.addTag(query);
             }
-            this.addTag(query);
         }
 
         // when backspace key is pressed and query is blank, delete tag
-        if (e.keyCode === Keys.BACKSPACE && query == "" && this.props.allowDeleteFromEmptyInput) { //
+        if (e.keyCode === Keys.BACKSPACE && query == "" && this.props.allowDeleteFromEmptyInput) {
             this.handleDelete(this.props.tags.length - 1);
         }
 
@@ -222,5 +228,6 @@ var ReactTags = React.createClass({
 
 module.exports = {
     WithContext: DragDropContext(HTML5Backend)(ReactTags),
-    WithOutContext: ReactTags
+    WithOutContext: ReactTags,
+    Keys: Keys
 };


### PR DESCRIPTION
It's possible now to specify keys that, when pressed, apply current input. Previously those keys were hardcoded. Default behaviour does not change - enter and tab still terminate the input by default.

Now exporting ``Keys`` to allow library users to reuse some of react-tag-input codes.

Also added ``minQueryLength`` to README because it was missing (separate commit).