### PR TITLE
bugfix: user input was interpreted as a regular expression

### DIFF
--- a/lib/reactTags.js
+++ b/lib/reactTags.js
@@ -77,7 +77,7 @@ var ReactTags = React.createClass({
 
         var query = e.target.value.trim();
         var suggestions = this.props.suggestions.filter(function(item) {
-            return (item.toLowerCase()).search(query.toLowerCase()) === 0;
+            return item.toLowerCase().startsWith(query.toLowerCase());
         });
 
         this.setState({


### PR DESCRIPTION
It would crash if the input was an invalid regular expression, like 'aaa['. It would match everything if the input was '..' or '.*'. Now it's interpreting the input as a string.