### PR TITLE
Allow non-suggested tags to be used with autocomplete

### DIFF
--- a/lib/reactTags.js
+++ b/lib/reactTags.js
@@ -156,7 +156,7 @@ var ReactTags = React.createClass({
           var possibleMatches = this.filteredSuggestions(tag, this.props.suggestions);
 
           if ( (this.props.autocomplete === 1 && possibleMatches.length === 1) ||
-                this.props.autocomplete === true)  {
+                this.props.autocomplete === true && possibleMatches.length)  {
             tag = possibleMatches[0]
           }
         }


### PR DESCRIPTION
If I enter a non-suggested tag with autocomplete enabled the component creates an empty tag. This patch allows one to still add non-suggested tags with the benefit of autocompleting any suggestions.