### PR TITLE
Fix warning: Each child in an array or iterator should have a unique key

### DIFF
--- a/lib/reactTags.js
+++ b/lib/reactTags.js
@@ -202,7 +202,7 @@ var ReactTags = React.createClass({
     },
     render: function() {
         var tagItems = this.props.tags.map(function(tag, i) {
-            return <Tag key={tag.id}
+            return <Tag key={tag.id || i}
                         tag={tag}
                         labelField={this.props.labelField}
                         onDelete={this.handleDelete.bind(this, i)}


### PR DESCRIPTION

Fixes issue #33

Set tag entry id as key for newly added tags (for example the tags is not saved in database, they don't have tag id)