### PR TITLE
Use ✕ instead of x for default remove component

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -65,7 +65,7 @@ var Tag = React.createClass({
             if (CustomRemoveComponent) {
               return <CustomRemoveComponent {...this.props} />;
             }
-            return <a {...this.props}>x</a>;
+            return <a {...this.props}>&#10005;</a>;
           }
         });
         var tagComponent = (


### PR DESCRIPTION
Changes the default remove component to use a proper cross (✕) symbol instead of the letter "x". 