### PR TITLE
stopPropagation of ESC key

### DIFF
--- a/lib/reactTags.js
+++ b/lib/reactTags.js
@@ -114,6 +114,7 @@ var ReactTags = React.createClass({
         // hide suggestions menu on escape
         if (e.keyCode === Keys.ESCAPE) {
             e.preventDefault();
+            e.stopPropagation();
             this.setState({
                 selectedIndex: -1,
                 selectionMode: false,


### PR DESCRIPTION
If `react-tags` catches the ESC key to close the suggestions menu it should not be allowed to propagate into the parent application.