### PR TITLE
Using fromCharCode instead of HTML entity for representing close

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -70,7 +70,7 @@ var Tag = React.createClass({
             if (CustomRemoveComponent) {
               return <CustomRemoveComponent {...this.props} />;
             }
-            return <a {...this.props}>&#10005;</a>;
+            return <a {...this.props}>{String.fromCharCode(215)}</a>;
           }
         });
         var tagComponent = (


### PR DESCRIPTION
If you notice [in your source code](https://github.com/prakhar1989/react-tags/blob/master/dist-modules/tag.js#L92), the close button &mdash; despite being represented in its HTML entity form in your source code &mdash; is rendered as an actual &times; in the `dist-modules`. This causes problems in certain encoding environments.

I've changed the HTML entity to using `String.fromCharCode` which should eliminate this problem 👍 

There's no reason why this change should cause any issues, and so I think a simple patch update should do the trick.