### PR TITLE
Clearing input once invoked onBlur handler

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -111,7 +111,8 @@ var ReactTags = React.createClass({
   handleBlur: function(e) {
     var value = e.target.value.trim();
     if (this.props.handleInputBlur && value.length){
-      this.props.handleInputBlur(value)
+      this.props.handleInputBlur(value);
+      this.refs.input.value = "";
     }
   },
   handleKeyDown: function(e) {

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -30,7 +30,7 @@ class Suggestions extends Component {
     const suggestions = props.suggestions.map(function (item, i) {
       return (
         <li key={i}
-        onClick={props.handleClick.bind(null, i) }
+        onMouseDown={props.handleClick.bind(null, i) }
         onMouseOver={props.handleHover.bind(null, i) }
         className={i == props.selectedIndex ? "active" : ""}>
         <span dangerouslySetInnerHTML={this.markIt(item, props.query) } />

--- a/test/reactTags-test.js
+++ b/test/reactTags-test.js
@@ -49,6 +49,7 @@ describe("ReactTags", () => {
     $el.find('.ReactTags__tagInput input').simulate('blur');
     expect(handleInputBlur.callCount).to.equal(1);
     expect(handleInputBlur.calledWith('Example')).to.be.true;
+    expect($el.find('.ReactTags__tagInput input').get(0).value).to.be.empty;
 
   });
 });


### PR DESCRIPTION
Sorry &mdash; a little oversight!

I think once we've invoked the `handleInputBlur` function, the `input` should be cleared, as the assumption is that the text was added as a tag.

Alternatively we could clear the input based on the return value of the `handleInputBlur` function, but that seems like it could cause confusion, although it would offer the developer greater control.