### PR TITLE
Asserting that the shift key isn't being held down

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -141,7 +141,7 @@ var ReactTags = React.createClass({
     // When one of the terminating keys is pressed, add current query to the tags.
     // If no text is typed in so far, ignore the action - so we don't end up with a terminating
     // character typed in.
-    if (this.props.delimiters.indexOf(e.keyCode) !== -1) {
+    if (this.props.delimiters.indexOf(e.keyCode) !== -1 && !e.shiftKey) {
       if (e.keyCode !== Keys.TAB || query !== "") {
         e.preventDefault();
       }


### PR DESCRIPTION
In [the example](http://prakhar.me/react-tags/example/) holding down <kbd>shift</kbd> whilst pressing <kdb>enter</kbd> adds the tag, when in reality that key combination is technically different from just <kbd>enter</kbd>.

For the above example it doesn't matter too much, but when you set your `delimiter` to <kbd>tab</kbd> for instance, then you're unable to enter <kbd><</kbd> into the textbox because the `keyCode` for <kbd>,</kbd> is the same as <kbd><</kbd> and thus takes it as the `delimiter`.

This change ensures the <kdb>shift</kbd> isn't being held down. Interestingly I couldn't find any tests for `addTag` and so I didn't add a test for this PR. Existing tests pass just fine.

I don't imagine this change will affect anybody as it really is an edge-case, however it is a breaking change.