### PR TITLE
Using passed delimiters to split pasted content

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -188,11 +188,21 @@ var ReactTags = React.createClass({
   },
   handlePaste: function (e) {
     e.preventDefault()
-    const clipboardData = e.clipboardData || window.clipboardData
-    const string = clipboardData.getData('text')
 
-    // split the pasted text on any whitespace or comma character and add each tag
-    string.split(/[\s,]+/).forEach((tag) => this.props.handleAddition(tag))
+    function escapeRegex(str) {
+      return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+    }
+
+    var chars = escapeRegex(this.props.delimiters.map(delimiter => {
+      // See: http://stackoverflow.com/a/34711175/1463681
+      var chrCode = delimiter - 48 * Math.floor(delimiter / 48);
+      return String.fromCharCode((96 <= delimiter) ? chrCode: delimiter);
+    }).join(''))
+
+    var clipboardData = e.clipboardData || window.clipboardData
+    var string = clipboardData.getData('text')
+    var regExp = new RegExp('[' + chars + ']+')
+    string.split(regExp).forEach((tag) => this.props.handleAddition(tag))
   },
   addTag: function(tag) {
     var input = this.refs.input;

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -189,19 +189,18 @@ var ReactTags = React.createClass({
   handlePaste: function (e) {
     e.preventDefault()
 
-    function escapeRegex(str) {
-      return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
-    }
+    // See: http://stackoverflow.com/a/6969486/1463681
+    const escapeRegex = str => str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 
-    var chars = escapeRegex(this.props.delimiters.map(delimiter => {
+    const chars = escapeRegex(this.props.delimiters.map(delimiter => {
       // See: http://stackoverflow.com/a/34711175/1463681
-      var chrCode = delimiter - 48 * Math.floor(delimiter / 48);
-      return String.fromCharCode((96 <= delimiter) ? chrCode: delimiter);
+      const chrCode = delimiter - 48 * Math.floor(delimiter / 48);
+      return String.fromCharCode((96 <= delimiter) ? chrCode: delimiter)
     }).join(''))
 
-    var clipboardData = e.clipboardData || window.clipboardData
-    var string = clipboardData.getData('text')
-    var regExp = new RegExp('[' + chars + ']+')
+    const clipboardData = e.clipboardData || window.clipboardData
+    const string = clipboardData.getData('text')
+    const regExp = new RegExp(`[${chars}]+`)
     string.split(regExp).forEach((tag) => this.props.handleAddition(tag))
   },
   addTag: function(tag) {

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -192,7 +192,8 @@ var ReactTags = React.createClass({
     // See: http://stackoverflow.com/a/6969486/1463681
     const escapeRegex = str => str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 
-    const chars = escapeRegex(this.props.delimiters.map(delimiter => {
+    // Used to determine how the pasted content is split.
+    const delimiterChars = escapeRegex(this.props.delimiters.map(delimiter => {
       // See: http://stackoverflow.com/a/34711175/1463681
       const chrCode = delimiter - 48 * Math.floor(delimiter / 48);
       return String.fromCharCode((96 <= delimiter) ? chrCode: delimiter)
@@ -200,7 +201,7 @@ var ReactTags = React.createClass({
 
     const clipboardData = e.clipboardData || window.clipboardData
     const string = clipboardData.getData('text')
-    const regExp = new RegExp(`[${chars}]+`)
+    const regExp = new RegExp(`[${delimiterChars}]+`)
     string.split(regExp).forEach((tag) => this.props.handleAddition(tag))
   },
   addTag: function(tag) {

--- a/test/reactTags-test.js
+++ b/test/reactTags-test.js
@@ -63,7 +63,7 @@ describe("ReactTags", () => {
     const actual = [];
     const $el = mount(
         mockItem({
-          delimiters: [188],
+          delimiters: [9, 32, 188],
           handleAddition(tag) {
             actual.push(tag)
           }
@@ -75,11 +75,11 @@ describe("ReactTags", () => {
 
     $input.simulate('paste', {
       clipboardData: {
-        getData: () => 'Banana,Apple,Apricot\nOrange,Pear,Peach\tKiwi'
+        getData: () => 'Banana,Apple,Apricot\nOrange Blueberry,Pear,Peach\tKiwi'
       }
     })
 
-    expect(actual).to.have.members(['Banana', 'Apple', 'Apricot\nOrange', 'Pear', 'Peach\tKiwi'])
+    expect(actual).to.have.members(['Banana', 'Apple', 'Apricot\nOrange', 'Blueberry', 'Pear', 'Peach', 'Kiwi'])
   })
 
   describe('autocomplete/suggestions filtering', () => {

--- a/test/reactTags-test.js
+++ b/test/reactTags-test.js
@@ -60,10 +60,16 @@ describe("ReactTags", () => {
 
   it("handles the paste event and splits the clipboard on delimiters", () => {
 
+    const Keys = {
+        TAB: 9,
+        SPACE: 32,
+        COMMA: 188
+    };
+
     const actual = [];
     const $el = mount(
         mockItem({
-          delimiters: [9, 32, 188],
+          delimiters: [Keys.TAB, Keys.SPACE, Keys.COMMA],
           handleAddition(tag) {
             actual.push(tag)
           }

--- a/test/reactTags-test.js
+++ b/test/reactTags-test.js
@@ -58,11 +58,12 @@ describe("ReactTags", () => {
 
   });
 
-  it("handles the paste event and splits the clipboard on whitespace or comma characters", () => {
+  it("handles the paste event and splits the clipboard on delimiters", () => {
 
     const actual = [];
     const $el = mount(
         mockItem({
+          delimiters: [188],
           handleAddition(tag) {
             actual.push(tag)
           }
@@ -74,11 +75,11 @@ describe("ReactTags", () => {
 
     $input.simulate('paste', {
       clipboardData: {
-        getData: () => 'Banana\nApple\tApricot, Pear\r\t  Peach,\t\n\r, Kiwi'
+        getData: () => 'Banana,Apple,Apricot\nOrange,Pear,Peach\tKiwi'
       }
     })
 
-    expect(actual).to.have.members(['Banana', 'Apple', 'Apricot', 'Pear', 'Peach', 'Kiwi'])
+    expect(actual).to.have.members(['Banana', 'Apple', 'Apricot\nOrange', 'Pear', 'Peach\tKiwi'])
   })
 
   describe('autocomplete/suggestions filtering', () => {


### PR DESCRIPTION
`react-tags` allows developers to specify the delimiters, but when it comes to `handlePaste` it disregards those delimiters and uses `\s,` which is undesirable because your pasted content *may* allow spaces and commas in its content, depending on your chosen delimiter(s).

~~There doesn't seem to be any tests relating to `handlePaste` so I haven't added one at this stage.~~