### PR TITLE
Fix adding a new tag in SelectionMode

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -147,7 +147,7 @@ var ReactTags = React.createClass({
       }
 
       if (query !== "") {
-        if (this.state.selectionMode) {
+        if (this.state.selectionMode && this.state.selectedIndex != -1) {
           query = this.state.suggestions[this.state.selectedIndex];
         }
         this.addTag(query);


### PR DESCRIPTION
Step to reproduce:
- Run the `npm run dev` example with `autocomplete={true}` props
- Type `Ind` and navigate in the suggestions without validate
- Type additional characters to have no suggestions, ie `Indy`
- Press enter
- The new tag is not added

=> `Uncaught TypeError: Cannot read property 'toLowerCase' of undefined`
