### PR TITLE
Add the ability to pass in a custom className for the <input> element

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Renders the component in read-only mode without the input box and `removeCompone
 
 - `ReactTags__tags`
 - `ReactTags__tagInput`
+- `ReactTags__tagInputField`
 - `ReactTags__selected`
 - `ReactTags__selected ReactTags__tag`
 - `ReactTags__selected ReactTags__remove`
@@ -320,6 +321,7 @@ a `classNames` prop.
     classNames={{
       tags: 'tagsClass',
       tagInput: 'tagInputClass',
+      tagInputField: 'tagInputFieldClass',
       selected: 'selectedClass',
       tag: 'tagClass',
       remove: 'removeClass',

--- a/example/reactTags.css
+++ b/example/reactTags.css
@@ -9,8 +9,8 @@ div.ReactTags__tagInput {
     border-radius: 2px;
     display: inline-block;
 }
-div.ReactTags__tagInput input, 
-div.ReactTags__tagInput input:focus {
+div.ReactTags__tagInput input.ReactTags__tagInputField,
+div.ReactTags__tagInput input.ReactTags__tagInputField:focus {
     height: 31px;
     margin: 0;
     font-size: 12px;

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -18,6 +18,7 @@ const Keys = {
 const DefaultClassNames = {
   tags: 'ReactTags__tags',
   tagInput: 'ReactTags__tagInput',
+  tagInputField: 'ReactTags__tagInputField',
   selected: 'ReactTags__selected',
   tag: 'ReactTags__tag',
   remove: 'ReactTags__remove',
@@ -275,6 +276,7 @@ var ReactTags = React.createClass({
       <div className={this.state.classNames.tagInput}>
 
         <input ref="input"
+          className={this.state.classNames.tagInputField}
           type="text"
           placeholder={placeholder}
           aria-label={placeholder}

--- a/test/reactTags-test.js
+++ b/test/reactTags-test.js
@@ -26,6 +26,7 @@ describe("ReactTags", () => {
     expect($el.find('.ReactTags__tags').length).to.equal(1);
     expect($el.find('.ReactTags__selected').length).to.equal(1);
     expect($el.find('.ReactTags__tagInput').length).to.equal(1);
+    expect($el.find('.ReactTags__tagInputField').length).to.equal(1);
   });
 
   it("renders preselected tags properly", () => {
@@ -39,22 +40,22 @@ describe("ReactTags", () => {
     const $el = mount(mockItem());
 
     // Won't be invoked as there's no `handleInputBlur` event yet.
-    $el.find('.ReactTags__tagInput input').simulate('blur');
+    $el.find('.ReactTags__tagInputField').simulate('blur');
     expect(handleInputBlur.callCount).to.equal(0);
 
     // Will be invoked despite the input being empty.
     $el.setProps({ handleInputBlur });
-    $el.find('.ReactTags__tagInput input').simulate('blur');
+    $el.find('.ReactTags__tagInputField').simulate('blur');
     expect(handleInputBlur.callCount).to.equal(1);
     expect(handleInputBlur.calledWith('')).to.be.true;
-    expect($el.find('.ReactTags__tagInput input').get(0).value).to.be.empty;
+    expect($el.find('.ReactTags__tagInputField').get(0).value).to.be.empty;
 
     // Will also be invoked for when the input has a value.
-    $el.find('.ReactTags__tagInput input').get(0).value = 'Example';
-    $el.find('.ReactTags__tagInput input').simulate('blur');
+    $el.find('.ReactTags__tagInputField').get(0).value = 'Example';
+    $el.find('.ReactTags__tagInputField').simulate('blur');
     expect(handleInputBlur.callCount).to.equal(2);
     expect(handleInputBlur.calledWith('Example')).to.be.true;
-    expect($el.find('.ReactTags__tagInput input').get(0).value).to.be.empty;
+    expect($el.find('.ReactTags__tagInputField').get(0).value).to.be.empty;
 
   });
 
@@ -77,7 +78,7 @@ describe("ReactTags", () => {
     )
 
     const ReactTagsInstance = $el.instance().refs.child
-    const $input = $el.find('.ReactTags__tagInput input')
+    const $input = $el.find('.ReactTags__tagInputField')
 
     $input.simulate('paste', {
       clipboardData: {
@@ -92,7 +93,7 @@ describe("ReactTags", () => {
     it('updates suggestions state as expected based on default filter logic', () => {
       const $el = mount(mockItem())
       const ReactTagsInstance = $el.instance().refs.child
-      const $input = $el.find('.ReactTags__tagInput input')
+      const $input = $el.find('.ReactTags__tagInputField')
 
       expect(ReactTagsInstance.state.suggestions).to.have.members(defaults.suggestions)
 
@@ -114,7 +115,7 @@ describe("ReactTags", () => {
           })
       )
       const ReactTagsInstance = $el.instance().refs.child
-      const $input = $el.find('.ReactTags__tagInput input')
+      const $input = $el.find('.ReactTags__tagInputField')
 
       expect(ReactTagsInstance.state.suggestions).to.have.members(defaults.suggestions)
 
@@ -136,7 +137,7 @@ describe("ReactTags", () => {
           })
       )
       const ReactTagsInstance = $el.instance().refs.child
-      const $input = $el.find('.ReactTags__tagInput input')
+      const $input = $el.find('.ReactTags__tagInputField')
 
       expect(ReactTagsInstance.state.suggestions).to.have.members(defaults.suggestions)
 


### PR DESCRIPTION
In regards to issue #32 , adds the ability to pass in a custom className for the `<input>` element, rather than just the outer `<div>`.
