### PR TITLE
Prevent suggestions from rendering unless the values have changed

### DIFF
--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { isEqual } from 'lodash';
 
 const maybeScrollSuggestionIntoView  = (suggestionEl, suggestionsContainer) => {
   const containerHeight = suggestionsContainer.offsetHeight
@@ -23,6 +24,10 @@ class Suggestions extends Component {
     minQueryLength: React.PropTypes.number,
     shouldRenderSuggestions: React.PropTypes.func,
     classNames: React.PropTypes.object
+  }
+
+  shouldComponentUpdate = nextProps => {
+    return !isEqual(this.props.suggestions, nextProps.suggestions);
   }
 
   componentDidUpdate = prevProps => {

--- a/lib/Tag.js
+++ b/lib/Tag.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { DragSource, DropTarget } from 'react-dnd';
-import flow from 'lodash.flow';
+import { flow } from 'lodash';
 
 const ItemTypes = { TAG: 'tag' };
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": "https://github.com/prakhar1989/react-tags",
   "dependencies": {
-    "lodash.flow": "^3.3.0",
+    "lodash": "^4.14.1",
     "react-dnd": "^2.0.2",
     "react-dnd-html5-backend": "^2.0.0"
   },


### PR DESCRIPTION
Hi there!

I'm using your sweet library for a project and ran into some performance issues with the suggestions list. The main issue is that my parent component is rendering rapidly, which causes the `Suggestions` component to render again. Since the suggestions never actually changed, this is a bit of a waste.

My changes add a simple `shouldComponentUpdate` to the `Suggestions` component to prevent needless renders and improve performance.