### PR TITLE
Don't import all of `lodash`

### DIFF
--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 const maybeScrollSuggestionIntoView  = (suggestionEl, suggestionsContainer) => {
   const containerHeight = suggestionsContainer.offsetHeight

--- a/lib/Tag.js
+++ b/lib/Tag.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { DragSource, DropTarget } from 'react-dnd';
-import { flow } from 'lodash';
+import flow from 'lodash/flow';
 
 const ItemTypes = { TAG: 'tag' };
 


### PR DESCRIPTION
This cuts the bundle size by more than half.

Before:
```
rkm@hanekawa ~/Documents/git/react-tags (git)-[v4.6.1] % npm run build

> react-tag-input@4.6.1 build /Users/rkm/Documents/git/react-tags
> webpack -p && babel lib --out-dir dist-modules

Hash: 6327f95bd25ea655d754
Version: webpack 1.14.0
Time: 5478ms
           Asset    Size  Chunks             Chunk Names
ReactTags.min.js  115 kB       0  [emitted]  main
    + 116 hidden modules

WARNING in ReactTags.min.js from UglifyJs
Condition always true [./~/lodash/lodash.js:17041,0]
Dropping unreachable code [./~/lodash/lodash.js:17055,0]
lib/ReactTags.js -> dist-modules/ReactTags.js
lib/Suggestions.js -> dist-modules/Suggestions.js
lib/Tag.js -> dist-modules/Tag.js
```

After:
```
rkm@hanekawa ~/Documents/git/react-tags (git)-[master] % npm run build

> react-tag-input@4.6.1 build /Users/rkm/Documents/git/react-tags
> webpack -p && babel lib --out-dir dist-modules

Hash: 70c6a9348ba67c899629
Version: webpack 1.14.0
Time: 1911ms
           Asset     Size  Chunks             Chunk Names
ReactTags.min.js  51.6 kB       0  [emitted]  main
    + 154 hidden modules
lib/ReactTags.js -> dist-modules/ReactTags.js
lib/Suggestions.js -> dist-modules/Suggestions.js
lib/Tag.js -> dist-modules/Tag.js
```

```
rkm@hanekawa ~/Documents/git/react-tags (git)-[master] % npm run test

> react-tag-input@4.6.1 test /Users/rkm/Documents/git/react-tags
> mocha test/.setup.js test/**/*-test.js



  ReactTags
    ✓ shows the classnames of children properly (51ms)
    ✓ renders preselected tags properly
    ✓ invokes the onBlur event
    ✓ handles the paste event and splits the clipboard on delimiters
    autocomplete/suggestions filtering
      ✓ updates suggestions state as expected based on default filter logic
      ✓ updates suggestions state as expected based on custom filter logic
      ✓ updates selectedIndex state as expected based on changing suggestions

  Suggestions
    ✓ shows the classname properly
    ✓ renders all suggestions properly
    ✓ selects the correct suggestion
    ✓ should not render suggestion with less than minQueryLength
    ✓ should be able to override suggestion render
    ✓ should mark highlighted suggestions correctly
    ✓ should not wastefully re-render if the list of suggestions have not changed
    ✓ should re-render if there is an active query
    ✓ should re-render if the provided 'shouldRenderSuggestions' prop returns true

  Tag
    ✓ shows the classnames of children properly
    ✓ should show cross for removing tag when read-only is false
    ✓ should not show cross for removing tag when read-only is true
    ✓ renders passed in removed component correctly
    ✓ calls the delete handler correctly
    ✓ should be draggable
    ✓ should not be draggable if readOnly is true


  23 passing (462ms)
```