### PR TITLE
allow disabling tag addition when a value was pasted into input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Otherwise, you can simply import along with the backend itself (as shown above).
 - [`handleFilterSuggestions`](#handleFilterSuggestions)
 - [`autofocus`](#autofocus)
 - [`allowDeleteFromEmptyInput`](#allowDeleteFromEmptyInput)
+- [`allowAdditionFromPaste`](#allowAdditionFromPaste)
 - [`handleInputChange`](#handleInputChange)
 - [`handleInputBlur`](#handleInputBlur)
 - [`minQueryLength`](#minQueryLength)
@@ -302,6 +303,16 @@ Optional boolean param to control whether tags should be deleted when the 'Delet
 ```js
 <ReactTags
     allowDeleteFromEmptyInput={false}
+    ...>
+```
+
+<a name="allowAdditionFromPaste"></a>
+##### allowAdditionFromPaste (optional)
+Optional boolean param to control whether tags should be added when a value was pasted into Input Box.
+
+```js
+<ReactTags
+    allowAdditionFromPaste={false}
     ...>
 ```
 

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -39,6 +39,7 @@ var ReactTags = React.createClass({
     handleDrag: React.PropTypes.func,
     handleFilterSuggestions: React.PropTypes.func,
     allowDeleteFromEmptyInput: React.PropTypes.bool,
+    allowAdditionFromPaste: React.PropTypes.bool,
     handleInputChange: React.PropTypes.func,
     handleInputBlur: React.PropTypes.func,
     minQueryLength: React.PropTypes.number,
@@ -60,6 +61,7 @@ var ReactTags = React.createClass({
       autofocus: true,
       inline: true,
       allowDeleteFromEmptyInput: true,
+      allowAdditionFromPaste: true,
       minQueryLength: 2,
       autocomplete: false,
       readOnly: false,
@@ -191,6 +193,10 @@ var ReactTags = React.createClass({
     }
   },
   handlePaste: function (e) {
+    if (!this.props.allowAdditionFromPaste) {
+      return;
+    }
+
     e.preventDefault()
 
     // See: http://stackoverflow.com/a/6969486/1463681


### PR DESCRIPTION
I wanted to have ability to control whether tags should be added automatically when pasting values to the input field, but there was no such functionality. New property `allowAdditionFromPaste` is `true` by default, which doesn't change the default behaviour.