### PR TITLE
fix re-rendering of Suggestion to make use of nextProps

### DIFF
--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -33,8 +33,10 @@ class Suggestions extends Component {
     const shouldRenderSuggestions =
       props.shouldRenderSuggestions || this.shouldRenderSuggestions;
     return (
-      !isEqual(this.props.suggestions, nextProps.suggestions) ||
-      shouldRenderSuggestions(props.query)
+      !isEqual(props.suggestions, nextProps.suggestions) ||
+      shouldRenderSuggestions(nextProps.query) ||
+      shouldRenderSuggestions(nextProps.query) !=
+        shouldRenderSuggestions(props.query)
     );
   };
 
@@ -63,7 +65,7 @@ class Suggestions extends Component {
   shouldRenderSuggestions = query => {
     const { props } = this;
     const minQueryLength = props.minQueryLength || 2;
-    return props.query.length >= minQueryLength;
+    return query.length >= minQueryLength;
   };
 
   render = () => {

--- a/test/suggestions.test.js
+++ b/test/suggestions.test.js
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import { expect } from "chai";
 import { shallow, mount, render } from "enzyme";
 import { spy } from "sinon";
@@ -106,5 +107,29 @@ describe("Suggestions", function() {
     spy($el.nodes[0], "componentDidUpdate");
     $el.setProps({ suggestions: suggestions });
     expect($el.nodes[0].componentDidUpdate.called).to.equal(true);
+  });
+
+  test("should re-render when the query reaches minQueryLength", function() {
+    const suggestions = ["queue", "quiz", "quantify"];
+    let div = document.createElement("div");
+    let component = mockItem({
+      minQueryLength: 2,
+      query: "",
+      suggestions: suggestions,
+    });
+    var $el = ReactDOM.render(component, div);
+    spy($el, "componentDidUpdate");
+
+    // re-render with updated query prop
+    $el = ReactDOM.render(
+      mockItem({
+        minQueryLength: 2,
+        query: "qu",
+        suggestions: suggestions,
+      }),
+      div
+    );
+
+    expect($el.componentDidUpdate.called).to.equal(true);
   });
 });


### PR DESCRIPTION
Suggestions don't always render when they're supposed to (e.g. hitting `minQueryLength` is not sufficient, always have to hit `minQueryLength+1` for a render to occur). Looking at the implementation of `shouldComponentUpdate` and `shouldRenderSuggestions` suggests two issues

1. `shouldComponentUpdate` is ignoring nextProps
2. `shouldRenderSuggestions` is ignoring the `query` argument