### PR TITLE
Fix reset input when autofocus=false

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -57,15 +57,15 @@ class ReactTags extends Component {
   }
 
   resetAndFocusInput() {
-    const { autofocus, readOnly } = this.props;
-    if (autofocus && !readOnly) {
-      this.textInput.value = "";
-      this.textInput.focus();
-    }
+    this.textInput.value = "";
+    this.textInput.focus();
   }
 
   componentDidMount() {
-    this.resetAndFocusInput();
+    const { autofocus, readOnly } = this.props;
+    if (autofocus && !readOnly) {
+      this.resetAndFocusInput()
+    }
   }
 
   filteredSuggestions(query, suggestions) {

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -64,7 +64,7 @@ class ReactTags extends Component {
   componentDidMount() {
     const { autofocus, readOnly } = this.props;
     if (autofocus && !readOnly) {
-      this.resetAndFocusInput()
+      this.resetAndFocusInput();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/prakhar1989/react-tags/issues/165

Before bug, that can be replicated by setting `autofocus={false}` on the example.
![bug gif](https://cloud.githubusercontent.com/assets/5553498/25254980/860e1326-25f6-11e7-8dca-ae8b41d5817e.gif)

The bug came from https://github.com/prakhar1989/react-tags/commit/4429be7922173e25a764fb26ced8898a15e49edf?diff=split#diff-833c370f0b7e67628628a041d1984df3L211 , where after tag addition the input would only reset if autofocus wasn't false. I decided to move the if condition into only `componentDidMountt`, as I am under the assumption that the input should be focused after tag deletion regardless of the autofocus prop. 

I didn't see a way to add in a test to ensure the input gets cleared after adding a tag, but if that is possible please point me in the right direction!