### PR TITLE
Fix for duplicate key prop if tag has no id

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -269,7 +269,7 @@ class ReactTags extends Component {
       function(tag, i) {
         return (
           <Tag
-            key={tag.id}
+            key={tag.id ? tag.id : i}
             index={i}
             tag={tag}
             labelField={this.props.labelField}


### PR DESCRIPTION
If a tag doesn't have an id field, it would throw a duplicate key warning.
If a tag has an id prop, use that, if not, use the map index as a key.