### PR TITLE
Set autofocus default to false

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -366,7 +366,7 @@ ReactTags.defaultProps = {
   tags: [],
   suggestions: [],
   delimiters: [Keys.ENTER, Keys.TAB],
-  autofocus: true,
+  autofocus: false,
   inline: true,
   allowDeleteFromEmptyInput: true,
   minQueryLength: 2,


### PR DESCRIPTION
Input elements have their autofocus props set to false by default, yet this component has it as true. If used with other input fields this component will take over the focus even if that is not the intended behavior. Because of that autofocus (which really should be named autoFocus to go along with the naming convention) needs to disabled which really isn't intuitive.