### PR TITLE
Revert "chore(package.json): "require" node 5+ to build"

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,5 @@
     "sinon": "^2.1.0",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.2"
-  },
-  "engines": {
-    "node": ">=5.0.0"
   }
 }


### PR DESCRIPTION
This reverts commit c16490cc7eb20feff808e7112ece66199a5d3536, since it's only needed when building and fails unnecessarily when installed as a dependency in `node@4` (e.g., via `react-tag-input`).