### PR TITLE
Change Suggestions to use a ref function.

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -168,9 +168,8 @@ class ReactTags extends Component {
 
       let { selectedIndex, suggestions } = this.state;
 
-      selectedIndex = selectedIndex <= 0
-        ? suggestions.length - 1
-        : selectedIndex - 1;
+      selectedIndex =
+        selectedIndex <= 0 ? suggestions.length - 1 : selectedIndex - 1;
 
       this.setState({
         selectedIndex: selectedIndex,

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -41,16 +41,21 @@ class Suggestions extends Component {
   };
 
   componentDidUpdate = prevProps => {
-    const suggestionsContainer = this.refs.suggestionsContainer;
     const { selectedIndex, classNames } = this.props;
 
-    if (suggestionsContainer && prevProps.selectedIndex !== selectedIndex) {
-      const activeSuggestion = suggestionsContainer.querySelector(
+    if (
+      this.suggestionsContainer &&
+      prevProps.selectedIndex !== selectedIndex
+    ) {
+      const activeSuggestion = this.suggestionsContainer.querySelector(
         classNames.activeSuggestion
       );
 
       if (activeSuggestion) {
-        maybeScrollSuggestionIntoView(activeSuggestion, suggestionsContainer);
+        maybeScrollSuggestionIntoView(
+          activeSuggestion,
+          this.suggestionsContainer
+        );
       }
     }
   };
@@ -95,9 +100,13 @@ class Suggestions extends Component {
 
     return (
       <div
-        ref="suggestionsContainer"
+        ref={el => {
+          this.suggestionsContainer = el;
+        }}
         className={this.props.classNames.suggestions}>
-        <ul> {suggestions} </ul>
+        <ul>
+          {" "}{suggestions}{" "}
+        </ul>
       </div>
     );
   };


### PR DESCRIPTION
The newer React standard suggests using a function
for ref instead of a string. This makes a small
tweak to change Suggestions to this pattern.

The main change is pretty small and I believe it is already tested by an existing test. Let me know if that isn't the case and I will add one. The bulk of the changes came from `npm run format` as suggested in the coding guidelines and included the output.