### PR TITLE
Add optional 1ms delay to input focus

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -58,7 +58,14 @@ class ReactTags extends Component {
 
   resetAndFocusInput() {
     this.textInput.value = "";
-    this.textInput.focus();
+    
+    if (this.props.reactLiteFix){
+        setTimeout(() => {
+            this.textInput.focus();
+        }, 1);
+    } else {
+        this.textInput.focus();
+    }
   }
 
   componentDidMount() {
@@ -359,6 +366,7 @@ ReactTags.PropTypes = {
   name: PropTypes.string,
   id: PropTypes.string,
   maxLength: PropTypes.string,
+  reactLiteFix: PropTypes.bool
 };
 
 ReactTags.defaultProps = {
@@ -372,6 +380,7 @@ ReactTags.defaultProps = {
   minQueryLength: 2,
   autocomplete: false,
   readOnly: false,
+  reactLiteFix: false
 };
 
 module.exports = {


### PR DESCRIPTION
textInput.focus() doesn't work when using React-lite, there are some timing differences that mean the ref isn't available immediately. This adds props.reactLiteFix, which introduces a 1ms delay to fix it.
reactLiteFix is false by default, so doesn't change original behaviour.