### PR TITLE
Pass current tag object to removeComponent for conditional rendering

### DIFF
--- a/lib/Tag.js
+++ b/lib/Tag.js
@@ -91,6 +91,7 @@ class Tag extends Component {
         className={props.classNames.tag}>
         {label}
         <RemoveComponent
+          tag={props.tag}
           className={props.classNames.remove}
           removeComponent={props.removeComponent}
           onClick={props.onDelete}

--- a/test/tag.test.js
+++ b/test/tag.test.js
@@ -59,6 +59,16 @@ describe("Tag", () => {
     expect($el.text()).to.have.string("delete me");
   });
 
+  test("renders conditionaly passed in removed component correctly", () => {
+    const CustomConditionRemoveComponent = function(props) {
+      return props.tag.id === 1 ? null : <a className="removeTag">x</a>;
+    };
+    const $el = mount(
+      mockItem({ removeComponent: CustomConditionRemoveComponent })
+    );
+    expect($el.find(".removeTag").length).to.equal(0);
+  });
+
   test("calls the delete handler correctly", () => {
     const spy = sinon.spy();
     const $el = mount(mockItem({ onDelete: spy }));


### PR DESCRIPTION
Passing current tag object to removeComponent allow us to conditionally render remove component. This will help us to decide which tag is removable and which not without using readOnly prop do disable them all.