### PR TITLE
Update to use react 16

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -309,6 +309,7 @@ class ReactTags extends Component {
             name={inputName}
             id={inputId}
             maxLength={maxLength}
+            value={this.props.inputValue}
           />
 
           <Suggestions
@@ -359,6 +360,7 @@ ReactTags.PropTypes = {
   name: PropTypes.string,
   id: PropTypes.string,
   maxLength: PropTypes.string,
+  inputValue: PropTypes.string,
 };
 
 ReactTags.defaultProps = {

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -28,7 +28,7 @@ class Suggestions extends Component {
     classNames: PropTypes.object,
   };
 
-  shouldComponentUpdate = nextProps => {
+  shouldComponentUpdate(nextProps) {
     const { props } = this;
     const shouldRenderSuggestions =
       props.shouldRenderSuggestions || this.shouldRenderSuggestions;
@@ -40,7 +40,7 @@ class Suggestions extends Component {
     );
   };
 
-  componentDidUpdate = prevProps => {
+  componentDidUpdate(prevProps) {
     const suggestionsContainer = this.refs.suggestionsContainer;
     const { selectedIndex, classNames } = this.props;
 
@@ -68,7 +68,7 @@ class Suggestions extends Component {
     return query.length >= minQueryLength;
   };
 
-  render = () => {
+  render() {
     const { props } = this;
     const suggestions = props.suggestions.map(
       function(item, i) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,12 @@
   "author": "Prakhar Srivastav",
   "license": "MIT",
   "repository": "https://github.com/prakhar1989/react-tags",
+  "jest": {
+    "setupFiles": [
+      "raf/polyfill",
+      "./test/setupTest.js"
+    ]
+  },
   "dependencies": {
     "lodash": "^4.14.1",
     "prop-types": "^15.5.8",
@@ -30,8 +36,8 @@
     "react-dnd-html5-backend": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc",
-    "react-dom": "^0.14.0 || ^15.0.0-rc"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -42,18 +48,20 @@
     "babel-preset-stage-0": "^6.0.15",
     "babel-register": "^6.9.0",
     "chai": "^4.0.1",
-    "enzyme": "^2.3.0",
+    "enzyme": "^2.3.0 || ^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.0",
     "jest": "^20.0.0",
     "jsdom": "^10.0.0",
     "lodash": "4.17.4",
     "npm-run-all": "^4.0.2",
     "opn": "^5.0.0",
     "prettier": "^1.1.0",
-    "react": "^15.1.0",
+    "raf": "3.4.0",
+    "react": "^15.1.0 || ^16.0.0",
     "react-addons-test-utils": "^15.1.0",
     "react-dnd-test-backend": "^2.3.0",
-    "react-dom": "^15.5.4",
-    "react-test-renderer": "^15.5.4",
+    "react-dom": "^15.5.4 || ^16.0.0",
+    "react-test-renderer": "^15.5.4 || ^16.0.0",
     "sinon": "^3.0.0",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.4.2"

--- a/test/reactTags.test.js
+++ b/test/reactTags.test.js
@@ -66,14 +66,19 @@ test("invokes the onBlur event", () => {
   $el.find(".ReactTags__tagInputField").simulate("blur");
   expect(handleInputBlur.callCount).to.equal(1);
   expect(handleInputBlur.calledWith("")).to.be.true;
-  expect($el.find(".ReactTags__tagInputField").get(0).value).to.be.empty;
+  expect($el.find(".ReactTags__tagInputField").get(0).value).to.be.undefined;
+});
+
+test("invokes the onBlur event when input has value", () => {
+  const handleInputBlur = spy();
+  const $el = mount(mockItem({ inputValue: "Example" }));
 
   // Will also be invoked for when the input has a value.
-  $el.find(".ReactTags__tagInputField").get(0).value = "Example";
+  $el.setProps({ handleInputBlur });
   $el.find(".ReactTags__tagInputField").simulate("blur");
-  expect(handleInputBlur.callCount).to.equal(2);
+  expect(handleInputBlur.callCount).to.equal(1);
   expect(handleInputBlur.calledWith("Example")).to.be.true;
-  expect($el.find(".ReactTags__tagInputField").get(0).value).to.be.empty;
+  expect($el.find(".ReactTags__tagInputField").get(0).value).to.be.undefined;
 });
 
 test("handles the paste event and splits the clipboard on delimiters", () => {

--- a/test/setupTest.js
+++ b/test/setupTest.js
@@ -1,0 +1,4 @@
+import Enzyme from "enzyme";
+import React16Adapter from "enzyme-adapter-react-16";
+
+Enzyme.configure({ adapter: new React16Adapter() });

--- a/test/suggestions.test.js
+++ b/test/suggestions.test.js
@@ -75,9 +75,11 @@ describe("Suggestions", function() {
         suggestions: suggestions,
       })
     );
-    spy($el.nodes[0], "componentDidUpdate");
+
+    spy(Suggestions.prototype, "componentDidUpdate");
     $el.setProps({ suggestions: suggestions });
-    expect($el.nodes[0].componentDidUpdate.called).to.equal(false);
+    expect(Suggestions.prototype.componentDidUpdate.called).to.equal(false);
+    Suggestions.prototype.componentDidUpdate.restore();
   });
 
   test("should re-render if there is an active query", function() {
@@ -89,9 +91,10 @@ describe("Suggestions", function() {
         suggestions: suggestions,
       })
     );
-    spy($el.nodes[0], "componentDidUpdate");
+    spy(Suggestions.prototype, "componentDidUpdate");
     $el.setProps({ suggestions: suggestions });
-    expect($el.nodes[0].componentDidUpdate.called).to.equal(true);
+    expect(Suggestions.prototype.componentDidUpdate.called).to.equal(true);
+    Suggestions.prototype.componentDidUpdate.restore();
   });
 
   test("should re-render if the provided 'shouldRenderSuggestions' prop returns true", function() {
@@ -104,9 +107,10 @@ describe("Suggestions", function() {
         suggestions: suggestions,
       })
     );
-    spy($el.nodes[0], "componentDidUpdate");
+    spy(Suggestions.prototype, "componentDidUpdate");
     $el.setProps({ suggestions: suggestions });
-    expect($el.nodes[0].componentDidUpdate.called).to.equal(true);
+    expect(Suggestions.prototype.componentDidUpdate.called).to.equal(true);
+    Suggestions.prototype.componentDidUpdate.restore();
   });
 
   test("should re-render when the query reaches minQueryLength", function() {

--- a/test/tag.test.js
+++ b/test/tag.test.js
@@ -42,12 +42,12 @@ describe("Tag", () => {
 
   test("should show cross for removing tag when read-only is false", () => {
     const $el = mount(mockItem());
-    expect($el.find(".remove").length).to.equal(1);
+    expect($el.find("a.remove").length).to.equal(1);
   });
 
   test("should not show cross for removing tag when read-only is true", () => {
     const $el = mount(mockItem({ readOnly: true }));
-    expect($el.find(".remove").length).to.equal(0);
+    expect($el.find("a.remove").length).to.equal(0);
   });
 
   test("renders passed in removed component correctly", () => {
@@ -55,14 +55,14 @@ describe("Tag", () => {
       return <a className="remove">delete me</a>;
     };
     const $el = mount(mockItem({ removeComponent: CustomRemoveComponent }));
-    expect($el.find(".remove").length).to.equal(1);
+    expect($el.find("a.remove").length).to.equal(1);
     expect($el.text()).to.have.string("delete me");
   });
 
   test("calls the delete handler correctly", () => {
     const spy = sinon.spy();
     const $el = mount(mockItem({ onDelete: spy }));
-    $el.find(".remove").simulate("click");
+    $el.find("a.remove").simulate("click");
     expect(spy.calledOnce).to.be.true;
   });
 


### PR DESCRIPTION
Update to react 16
* `inputValue` props is necessary because setting the input field value throws `TypeError: Can't add property value, object is not extensible` see the test that was split into 2