### PR TITLE
Issue 36 - Showing all items + Keyboard selection when minQueryLength=0 

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -36,10 +36,12 @@ class ReactTags extends Component {
     this.state = {
       suggestions: this.props.suggestions,
       query: "",
+      isFocused: false,
       selectedIndex: -1,
       selectionMode: false,
     };
 
+    this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleChange = this.handleChange.bind(this);
@@ -115,12 +117,17 @@ class ReactTags extends Component {
     });
   }
 
+  handleFocus() {
+    this.setState({ isFocused: true });
+  }
+
   handleBlur(e) {
     const value = e.target.value.trim();
     if (this.props.handleInputBlur) {
       this.props.handleInputBlur(value);
       this.textInput.value = "";
     }
+    this.setState({ isFocused: false });
   }
 
   handleKeyDown(e) {
@@ -145,10 +152,10 @@ class ReactTags extends Component {
         e.preventDefault();
       }
 
+      if (this.state.selectionMode && this.state.selectedIndex != -1) {
+        query = this.state.suggestions[this.state.selectedIndex];
+      }
       if (query !== "") {
-        if (this.state.selectionMode && this.state.selectedIndex != -1) {
-          query = this.state.suggestions[this.state.selectedIndex];
-        }
         this.addTag(query);
       }
     }
@@ -302,6 +309,7 @@ class ReactTags extends Component {
             type="text"
             placeholder={placeholder}
             aria-label={placeholder}
+            onFocus={this.handleFocus}
             onBlur={this.handleBlur}
             onChange={this.handleChange}
             onKeyDown={this.handleKeyDown}
@@ -319,6 +327,7 @@ class ReactTags extends Component {
             handleHover={this.handleSuggestionHover}
             minQueryLength={this.props.minQueryLength}
             shouldRenderSuggestions={this.props.shouldRenderSuggestions}
+            isFocused={this.state.isFocused}
             classNames={this.state.classNames}
           />
         </div>

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -175,9 +175,8 @@ class ReactTags extends Component {
 
       let { selectedIndex, suggestions } = this.state;
 
-      selectedIndex = selectedIndex <= 0
-        ? suggestions.length - 1
-        : selectedIndex - 1;
+      selectedIndex =
+        selectedIndex <= 0 ? suggestions.length - 1 : selectedIndex - 1;
 
       this.setState({
         selectedIndex: selectedIndex,
@@ -299,39 +298,39 @@ class ReactTags extends Component {
       inputId = this.props.id,
       maxLength = this.props.maxLength;
 
-    const tagInput = !this.props.readOnly
-      ? <div className={this.state.classNames.tagInput}>
-          <input
-            ref={input => {
-              this.textInput = input;
-            }}
-            className={this.state.classNames.tagInputField}
-            type="text"
-            placeholder={placeholder}
-            aria-label={placeholder}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
-            onChange={this.handleChange}
-            onKeyDown={this.handleKeyDown}
-            onPaste={this.handlePaste}
-            name={inputName}
-            id={inputId}
-            maxLength={maxLength}
-          />
+    const tagInput = !this.props.readOnly ? (
+      <div className={this.state.classNames.tagInput}>
+        <input
+          ref={input => {
+            this.textInput = input;
+          }}
+          className={this.state.classNames.tagInputField}
+          type="text"
+          placeholder={placeholder}
+          aria-label={placeholder}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKeyDown}
+          onPaste={this.handlePaste}
+          name={inputName}
+          id={inputId}
+          maxLength={maxLength}
+        />
 
-          <Suggestions
-            query={query}
-            suggestions={suggestions}
-            selectedIndex={selectedIndex}
-            handleClick={this.handleSuggestionClick}
-            handleHover={this.handleSuggestionHover}
-            minQueryLength={this.props.minQueryLength}
-            shouldRenderSuggestions={this.props.shouldRenderSuggestions}
-            isFocused={this.state.isFocused}
-            classNames={this.state.classNames}
-          />
-        </div>
-      : null;
+        <Suggestions
+          query={query}
+          suggestions={suggestions}
+          selectedIndex={selectedIndex}
+          handleClick={this.handleSuggestionClick}
+          handleHover={this.handleSuggestionHover}
+          minQueryLength={this.props.minQueryLength}
+          shouldRenderSuggestions={this.props.shouldRenderSuggestions}
+          isFocused={this.state.isFocused}
+          classNames={this.state.classNames}
+        />
+      </div>
+    ) : null;
 
     return (
       <div className={this.state.classNames.tags}>

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -25,6 +25,7 @@ class Suggestions extends Component {
     handleHover: PropTypes.func.isRequired,
     minQueryLength: PropTypes.number,
     shouldRenderSuggestions: PropTypes.func,
+    isFocused: PropTypes.bool.isRequired,
     classNames: PropTypes.object,
   };
 
@@ -33,6 +34,7 @@ class Suggestions extends Component {
     const shouldRenderSuggestions =
       props.shouldRenderSuggestions || this.shouldRenderSuggestions;
     return (
+      props.isFocused !== nextProps.isFocused ||
       !isEqual(props.suggestions, nextProps.suggestions) ||
       shouldRenderSuggestions(nextProps.query) ||
       shouldRenderSuggestions(nextProps.query) !=
@@ -64,8 +66,8 @@ class Suggestions extends Component {
 
   shouldRenderSuggestions = query => {
     const { props } = this;
-    const minQueryLength = props.minQueryLength || 2;
-    return query.length >= minQueryLength;
+    const minQueryLength = Number.isInteger(props.minQueryLength) ? props.minQueryLength : 2;
+    return query.length >= minQueryLength && props.isFocused;
   };
 
   render = () => {

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -66,7 +66,9 @@ class Suggestions extends Component {
 
   shouldRenderSuggestions = query => {
     const { props } = this;
-    const minQueryLength = Number.isInteger(props.minQueryLength) ? props.minQueryLength : 2;
+    const minQueryLength = Number.isInteger(props.minQueryLength)
+      ? props.minQueryLength
+      : 2;
     return query.length >= minQueryLength && props.isFocused;
   };
 

--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -40,7 +40,7 @@ class Suggestions extends Component {
       shouldRenderSuggestions(nextProps.query) !=
         shouldRenderSuggestions(props.query)
     );
-  };
+  }
 
   componentDidUpdate(prevProps) {
     const suggestionsContainer = this.refs.suggestionsContainer;
@@ -55,7 +55,7 @@ class Suggestions extends Component {
         maybeScrollSuggestionIntoView(activeSuggestion, suggestionsContainer);
       }
     }
-  };
+  }
 
   markIt = (input, query) => {
     const escapedRegex = query.trim().replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&");
@@ -104,7 +104,7 @@ class Suggestions extends Component {
         <ul> {suggestions} </ul>
       </div>
     );
-  };
+  }
 }
 
 export default Suggestions;

--- a/test/reactTags.test.js
+++ b/test/reactTags.test.js
@@ -196,15 +196,17 @@ describe("autocomplete/suggestions filtering", () => {
     expect(ReactTagsInstance.state.selectedIndex).to.equal(0);
   });
 
-  test("selects the correct suggestion using the keyboard when minQueryLength is set to 0", function () {
+  test("selects the correct suggestion using the keyboard when minQueryLength is set to 0", function() {
     let actual = [];
-    const $el = mount(mockItem({
-      query: "",
-      minQueryLength: 0,
-      handleAddition(tag) {
-        actual.push(tag);
-      }
-    }));
+    const $el = mount(
+      mockItem({
+        query: "",
+        minQueryLength: 0,
+        handleAddition(tag) {
+          actual.push(tag);
+        },
+      })
+    );
     const $input = $el.find(".ReactTags__tagInputField");
 
     $input.simulate("keyDown", { keyCode: DOWN_ARROW_KEY_CODE });

--- a/test/reactTags.test.js
+++ b/test/reactTags.test.js
@@ -15,6 +15,7 @@ const defaults = {
 };
 
 const DOWN_ARROW_KEY_CODE = 40;
+const ENTER_ARROW_KEY_CODE = 13;
 
 function mockItem(overrides) {
   const props = Object.assign({}, defaults, overrides);
@@ -193,5 +194,25 @@ describe("autocomplete/suggestions filtering", () => {
     $input.simulate("change", { target: { value: "Each" } });
     expect(ReactTagsInstance.state.suggestions).to.have.members(["Peach"]);
     expect(ReactTagsInstance.state.selectedIndex).to.equal(0);
+  });
+
+  test("selects the correct suggestion using the keyboard when minQueryLength is set to 0", function () {
+    let actual = [];
+    const $el = mount(mockItem({
+      query: "",
+      minQueryLength: 0,
+      handleAddition(tag) {
+        actual.push(tag);
+      }
+    }));
+    const $input = $el.find(".ReactTags__tagInputField");
+
+    $input.simulate("keyDown", { keyCode: DOWN_ARROW_KEY_CODE });
+    $input.simulate("keyDown", { keyCode: DOWN_ARROW_KEY_CODE });
+    $input.simulate("keyDown", { keyCode: DOWN_ARROW_KEY_CODE });
+    $input.simulate("keyDown", { keyCode: ENTER_ARROW_KEY_CODE });
+    expect(actual).to.have.members(["Apricot"]);
+
+    $el.unmount();
   });
 });

--- a/test/suggestions.test.js
+++ b/test/suggestions.test.js
@@ -110,9 +110,10 @@ describe("Suggestions", function() {
         suggestions: suggestions,
       })
     );
-    spy($el.nodes[0], "componentDidUpdate");
+    spy(Suggestions.prototype, "componentDidUpdate");
     $el.setProps({ suggestions: suggestions });
-    expect($el.nodes[0].componentDidUpdate.called).to.equal(true);
+    expect(Suggestions.prototype.componentDidUpdate.called).to.equal(true);
+    Suggestions.prototype.componentDidUpdate.restore();
   });
 
   test("should re-render if the provided 'shouldRenderSuggestions' prop returns true", function() {

--- a/test/suggestions.test.js
+++ b/test/suggestions.test.js
@@ -62,9 +62,12 @@ describe("Suggestions", function() {
 
   test("should mark highlighted suggestions correctly", function() {
     const $el = shallow(mockItem());
-    expect($el.find("li.active").find("span").html()).to.equal(
-      "<span>M<mark>ang</mark>o</span>"
-    );
+    expect(
+      $el
+        .find("li.active")
+        .find("span")
+        .html()
+    ).to.equal("<span>M<mark>ang</mark>o</span>");
   });
 
   test("should not wastefully re-render if the list of suggestions have not changed", function() {

--- a/test/suggestions.test.js
+++ b/test/suggestions.test.js
@@ -11,6 +11,7 @@ function mockItem(overrides) {
     query: "ang",
     suggestions: ["Banana", "Mango", "Pear", "Apricot"],
     selectedIndex: 1,
+    isFocused: true,
     handleClick: noop,
     handleHover: noop,
     classNames: { suggestions: "foo", activeSuggestion: "active" },
@@ -86,6 +87,20 @@ describe("Suggestions", function() {
       mockItem({
         minQueryLength: 2,
         query: "qu",
+        suggestions: suggestions,
+      })
+    );
+    spy($el.nodes[0], "componentDidUpdate");
+    $el.setProps({ suggestions: suggestions });
+    expect($el.nodes[0].componentDidUpdate.called).to.equal(true);
+  });
+
+  test("should re-render if minQueryLength is set to 0", function() {
+    const suggestions = ["queue", "quiz", "quantify"];
+    const $el = mount(
+      mockItem({
+        minQueryLength: 0,
+        query: "",
         suggestions: suggestions,
       })
     );


### PR DESCRIPTION
Updated code so minQueryLength can be set to 0 in order to show suggestions when input is focused and allow keyboard selection when minQueryLength is set to 0.
Issue #36