### PR TITLE
Fix propTypes definition

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -337,7 +337,7 @@ class ReactTags extends Component {
   }
 }
 
-ReactTags.PropTypes = {
+ReactTags.propTypes = {
   placeholder: PropTypes.string,
   labelField: PropTypes.string,
   suggestions: PropTypes.array,


### PR DESCRIPTION
I get the error `Warning: Component ReactTags declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?`. This fixes that (and adds prop-types validation)