### PR TITLE
Add stackblitz for demoing library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Because I was looking for an excuse to build a standalone component and publish 
 ### Demo
 ![img](demo.gif)
 
-Check it out [here](http://prakhar1989.github.io/react-tags/example/)
+Check it out [here](https://react-tag-input.stackblitz.io)
 
 ### Installation
 The preferred way of using the component is via NPM
@@ -32,7 +32,7 @@ The preferred way of using the component is via NPM
 ```
 npm install --save react-tag-input
 ```
-It is, however, also available to be used separately (`dist/ReactTags.min.js`). If you prefer this method remember to include [ReactDND](https://github.com/gaearon/react-dnd) as a dependancy. Refer to the [demo](http://prakhar1989.github.io/react-tags/example/) to see how this works.
+It is, however, also available to be used separately (`dist/ReactTags.min.js`). If you prefer this method remember to include [ReactDND](https://github.com/gaearon/react-dnd) as a dependancy. Refer to the [example](https://stackblitz.com/edit/react-tag-input) to see how this works.
 
 ### Usage
 


### PR DESCRIPTION
I think the example included in the repo is hard to maintain and doesn't quite show the actual usage of the library, so adding a stackblitz demo which users can fork and play right in the browser might be a nice way to experiment.

Here's the demo: https://react-tag-input.stackblitz.io