### PR TITLE
add touch start event to Suggestion component

### DIFF
--- a/lib/Suggestions.js
+++ b/lib/Suggestions.js
@@ -86,6 +86,7 @@ class Suggestions extends Component {
             key={i}
             onMouseDown={props.handleClick.bind(null, i)}
             onMouseOver={props.handleHover.bind(null, i)}
+            onTouchStart={props.handleClick.bind(null, i)}
             className={
               i == props.selectedIndex ? props.classNames.activeSuggestion : ""
             }>

--- a/test/suggestions.test.js
+++ b/test/suggestions.test.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { expect } from "chai";
 import { shallow, mount, render } from "enzyme";
 import { spy } from "sinon";
+import sinon from "sinon";
 import Suggestions from "../lib/Suggestions";
 import noop from "lodash/noop";
 
@@ -154,5 +155,15 @@ describe("Suggestions", function() {
     );
 
     expect($el.componentDidUpdate.called).to.equal(true);
+  });
+
+  test("should call handleClick when touched", function() {
+    const s = spy();
+    const $el = mount(mockItem({ handleClick: s }));
+    $el
+      .find("li")
+      .at(0)
+      .simulate("touchStart");
+    expect(s.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION
The reason for this is to guarantee that handleClick is also called when suggestion item is 'touched' by user.
Corresponding issue: iOS can not click on item in suggestion list #251