### PR TITLE
fix peer dependencies issue in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["env", "stage-0", "react"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tag-input",
-  "version": "4.9.1",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
@@ -844,6 +844,12 @@
         }
       }
     },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true
+    },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
@@ -1097,6 +1103,12 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true
     },
+    "browserslist": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "dev": true
+    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -1192,6 +1204,12 @@
           "dev": true
         }
       }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000830",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
+      "integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -1836,6 +1854,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.42",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
+      "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
       "dev": true
     },
     "elliptic": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "jest --notify --coverage",
     "test-watch": "jest --watch --notify --coverage",
     "open-localhost": "node -e 'require(\"opn\")(\"http://localhost:8090/example/index.html\")'",
-    "test-watch": "jest --watch --notify",
     "dev": "webpack-dev-server --config webpack-dev-server.config.js --progress --inline --colors",
     "format": "prettier  --write lib/*.js test/*.js",
     "build": "webpack --config webpack-production.config.js --progress --colors && babel lib --out-dir dist-modules",
@@ -45,7 +44,7 @@
     "babel-core": "6.26.0",
     "babel-jest": "22.4.1",
     "babel-loader": "7.1.2",
-    "babel-preset-es2015": "6.24.1",
+    "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "babel-register": "6.26.0",
@@ -64,7 +63,7 @@
     "react-dnd-test-backend": "2.3.0",
     "react-test-renderer": "16.1.1",
     "sinon": "4.2.2",
-    "webpack": "4.2.0",
+    "webpack": "3.11.0",
     "webpack-dev-server": "2.11.1"
   }
 }


### PR DESCRIPTION
* Downgrading to webpack 3 as dev setup is breaking due to changes in webpack 4. Need to fix webpack config according webpack 4 then we can upgrade to webpack 4 and `webpack-dev-server` has peer dependency or webpack 1 || 2 || 3
* replace `babel-preset-es2015` with `babel-preset-env` as `babel-preset-es2015` is deprecated

* will fix the webpack config in different PR