### PR TITLE
Give handleAddition and handleDelete default props

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 import Suggestions from './Suggestions';
 import PropTypes from 'prop-types';
 import Tag from './Tag';

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -384,8 +384,8 @@ ReactTags.propTypes = {
   delimiters: PropTypes.array,
   autofocus: PropTypes.bool,
   inline: PropTypes.bool,
-  handleDelete: PropTypes.func.isRequired,
-  handleAddition: PropTypes.func.isRequired,
+  handleDelete: PropTypes.func,
+  handleAddition: PropTypes.func,
   handleDrag: PropTypes.func,
   handleFilterSuggestions: PropTypes.func,
   handleTagClick: PropTypes.func,
@@ -411,12 +411,16 @@ ReactTags.propTypes = {
   }))
 };
 
+const noop = () => {};
+
 ReactTags.defaultProps = {
   placeholder: DEFAULT_PLACEHOLDER,
   suggestions: [],
   delimiters: [KEYS.ENTER, KEYS.TAB],
   autofocus: true,
   inline: true,
+  handleDelete: noop,
+  handleAddition: noop,
   allowDeleteFromEmptyInput: true,
   allowAdditionFromPaste: true,
   resetInputOnDelete: true,

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
+import noop from 'lodash/noop';
 import Suggestions from './Suggestions';
 import PropTypes from 'prop-types';
 import Tag from './Tag';
@@ -410,8 +410,6 @@ ReactTags.propTypes = {
     text: PropTypes.any.isRequired
   }))
 };
-
-const noop = () => {};
 
 ReactTags.defaultProps = {
   placeholder: DEFAULT_PLACEHOLDER,

--- a/test/reactTags.test.js
+++ b/test/reactTags.test.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { spy } from 'sinon';
-import noop from 'lodash/noop';
 import { WithContext as ReactTags } from '../lib/ReactTags';
-import renderer from 'react-test-renderer';
 
 const defaults = {
   tags: [{ id: 'Apple', text: 'Apple' }],
@@ -15,9 +13,6 @@ const defaults = {
     { id: 'Pear', text: 'Pear' },
     { id: 'Peach', text: 'Peach' },
   ],
-  handleAddition: noop,
-  handleDelete: noop,
-  handleDrag: noop,
 };
 
 const DOWN_ARROW_KEY_CODE = 40;


### PR DESCRIPTION
When `readOnly` is `true`, both `handleAddtion` and `handleDelete` are unused. Provide a noop function as a default prop and remove the requirement for them to be provided.

Fixes #303