### PR TITLE
Move the props and default props into the class

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -17,7 +17,7 @@ class ReactTags extends Component {
       id: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired
     })),
-    delimiters: PropTypes.array,
+    delimiters: PropTypes.arrayOf(PropTypes.number),
     autofocus: PropTypes.bool,
     inline: PropTypes.bool,
     handleDelete: PropTypes.func,

--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -10,6 +10,59 @@ import Tag from './Tag';
 import { KEYS, DEFAULT_PLACEHOLDER, DEFAULT_CLASSNAMES } from './constants';
 
 class ReactTags extends Component {
+  static propTypes = {
+    placeholder: PropTypes.string,
+    labelField: PropTypes.string,
+    suggestions: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      text: PropTypes.string.isRequired
+    })),
+    delimiters: PropTypes.array,
+    autofocus: PropTypes.bool,
+    inline: PropTypes.bool,
+    handleDelete: PropTypes.func,
+    handleAddition: PropTypes.func,
+    handleDrag: PropTypes.func,
+    handleFilterSuggestions: PropTypes.func,
+    handleTagClick: PropTypes.func,
+    allowDeleteFromEmptyInput: PropTypes.bool,
+    allowAdditionFromPaste: PropTypes.bool,
+    resetInputOnDelete: PropTypes.bool,
+    handleInputChange: PropTypes.func,
+    handleInputFocus: PropTypes.func,
+    handleInputBlur: PropTypes.func,
+    minQueryLength: PropTypes.number,
+    shouldRenderSuggestions: PropTypes.func,
+    removeComponent: PropTypes.func,
+    autocomplete: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
+    readOnly: PropTypes.bool,
+    classNames: PropTypes.object,
+    name: PropTypes.string,
+    id: PropTypes.string,
+    maxLength: PropTypes.string,
+    inputValue: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      text: PropTypes.any.isRequired
+    }))
+  };
+
+  static defaultProps = {
+    placeholder: DEFAULT_PLACEHOLDER,
+    suggestions: [],
+    delimiters: [KEYS.ENTER, KEYS.TAB],
+    autofocus: true,
+    inline: true,
+    handleDelete: noop,
+    handleAddition: noop,
+    allowDeleteFromEmptyInput: true,
+    allowAdditionFromPaste: true,
+    resetInputOnDelete: true,
+    minQueryLength: 2,
+    autocomplete: false,
+    readOnly: false,
+  };
+
   constructor(props) {
     super(props);
 
@@ -373,59 +426,6 @@ class ReactTags extends Component {
     );
   }
 }
-
-ReactTags.propTypes = {
-  placeholder: PropTypes.string,
-  labelField: PropTypes.string,
-  suggestions: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired
-  })),
-  delimiters: PropTypes.array,
-  autofocus: PropTypes.bool,
-  inline: PropTypes.bool,
-  handleDelete: PropTypes.func,
-  handleAddition: PropTypes.func,
-  handleDrag: PropTypes.func,
-  handleFilterSuggestions: PropTypes.func,
-  handleTagClick: PropTypes.func,
-  allowDeleteFromEmptyInput: PropTypes.bool,
-  allowAdditionFromPaste: PropTypes.bool,
-  resetInputOnDelete: PropTypes.bool,
-  handleInputChange: PropTypes.func,
-  handleInputFocus: PropTypes.func,
-  handleInputBlur: PropTypes.func,
-  minQueryLength: PropTypes.number,
-  shouldRenderSuggestions: PropTypes.func,
-  removeComponent: PropTypes.func,
-  autocomplete: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-  readOnly: PropTypes.bool,
-  classNames: PropTypes.object,
-  name: PropTypes.string,
-  id: PropTypes.string,
-  maxLength: PropTypes.string,
-  inputValue: PropTypes.string,
-  tags: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    text: PropTypes.any.isRequired
-  }))
-};
-
-ReactTags.defaultProps = {
-  placeholder: DEFAULT_PLACEHOLDER,
-  suggestions: [],
-  delimiters: [KEYS.ENTER, KEYS.TAB],
-  autofocus: true,
-  inline: true,
-  handleDelete: noop,
-  handleAddition: noop,
-  allowDeleteFromEmptyInput: true,
-  allowAdditionFromPaste: true,
-  resetInputOnDelete: true,
-  minQueryLength: 2,
-  autocomplete: false,
-  readOnly: false,
-};
 
 module.exports = {
   WithContext: DragDropContext(HTML5Backend)(ReactTags),


### PR DESCRIPTION
Per request from @ad1992 on #304, moving the prop types and default props into the `ReactTags` class and making them static members.