### PR TITLE
Import only wanted parts of lodash

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { noop, uniq } from 'lodash';
+import noop from 'lodash/noop';
+import uniq from 'lodash/uniq';
 import Suggestions from './Suggestions';
 import PropTypes from 'prop-types';
 import Tag from './Tag';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-import { escapeRegExp } from 'lodash';
+import escapeRegExp from 'lodash/escapeRegExp';
 
 /**
  * Convert an array of delimiter characters into a regular expression

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.2",
   "description": "React tags is a fantastically simple tagging component for your React projects",
   "main": "dist-modules/ReactTags.js",
+  "sideEffects": false,
   "scripts": {
     "test": "jest --notify --coverage",
     "test-watch": "jest --watch --notify --coverage",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "5.0.2",
   "description": "React tags is a fantastically simple tagging component for your React projects",
   "main": "dist-modules/ReactTags.js",
-  "sideEffects": false,
   "scripts": {
     "test": "jest --notify --coverage",
     "test-watch": "jest --watch --notify --coverage",

--- a/test/reactTags.test.js
+++ b/test/reactTags.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import { spy } from 'sinon';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 
 import { WithContext as ReactTags } from '../lib/ReactTags';
 


### PR DESCRIPTION
* By being explicit about what functions we want from lodash, we can reduce the bundle size by ~50%.
* Adding 'sideEffects: false' to package.json to allow webpack4 optimize re-exports (https://github.com/webpack/webpack/tree/master/examples/side-effects).

Before:
* ReactTags.min.js 143 kB

After:
* ReactTags.min.js 72.4 kB