### PR TITLE
fix autocomplete bug

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -282,7 +282,7 @@ class ReactTags extends Component {
     }
     if (this.props.autocomplete) {
       const possibleMatches = this.filteredSuggestions(
-        tag,
+        tag.text,
         this.props.suggestions
       );
 

--- a/test/reactTags.test.js
+++ b/test/reactTags.test.js
@@ -475,5 +475,23 @@ describe('Test ReactTags', () => {
 
       $el.unmount();
     });
+
+    test('handles addition when using default suggestions filter', () => {
+      let actual = [];
+      const $el = mount(
+        mockItem({
+          autocomplete: true,
+          handleAddition(tag) {
+            actual.push(tag);
+          },
+        })
+      );
+      const $input = $el.find('.ReactTags__tagInputField');
+
+      $input.simulate('change', { target: { value: 'Ea' } });
+      $input.simulate('focus');
+      $input.simulate('keyDown', { keyCode: ENTER_ARROW_KEY_CODE });
+      expect(actual).to.have.deep.members([{ id: 'Ea', text: 'Ea' }]);
+    });
   });
 });


### PR DESCRIPTION
The `tag` object was sent to `filteredSuggestions`, but the actual text was expected. Sending `tag.text` fixes the issue. Closes #342 