### PR TITLE
Change propTypes for maxLength

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -47,7 +47,7 @@ class ReactTags extends Component {
     classNames: PropTypes.object,
     name: PropTypes.string,
     id: PropTypes.string,
-    maxLength: PropTypes.string,
+    maxLength: PropTypes.number,
     inputValue: PropTypes.string,
     tags: PropTypes.arrayOf(
       PropTypes.shape({


### PR DESCRIPTION
While implementing the library i noticed that maxLength requires a number as a prop but in ReactTags.js a string is required.