### PR TITLE
feat: Add custom suggestion as a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Option | Type | Default | Description
 |[`inline`](#inline) | `Boolean` | `true` | Render input field and selected tags in-line
 |[`allowUnique`](#allowUnique) | `Boolean` | `true` | Boolean value to control whether tags should be unqiue
 |[`allowDragDrop`](#allowDragDrop) | `Boolean` | `true` | Boolean value to control whether tags should have drag-n-drop features enabled
+|[`customSuggestion`](#customSuggestion) | `Function` | `undefined` | Function that returns a custom suggestion for overriding the default one
 
 <a name="tagsOption"></a>
 ##### tags (optional, defaults to `[]`)
@@ -440,6 +441,16 @@ This prop controls whether tags should be unique.
 <a name="allowDragDrop"></a>
 #### allowDragDrop (optional, defaults to `true`)
 This prop controls whether tags should have the drag-n-drop feature enabled.
+
+<a name="customSuggestion"></a>
+#### customSuggestion (optional)
+This props allows to override the default suggestion component and return a custom one. It receives the suggestion and the query string as parameters. For example:
+
+```
+<ReactTags
+    customSuggestion = {({ text }, query) => <div style={{ textDecoration: 'underline', textDecorationStyle: 'wavy' }}>{text} ({ query })</div>}
+    ...>
+```
 
 ### Styling
 `<ReactTags>` does not come up with any styles. However, it is very easy to customize the look of the component the way you want it. By default, the component provides the following classes with which you can style -

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Option | Type | Default | Description
 |[`inline`](#inline) | `Boolean` | `true` | Render input field and selected tags in-line
 |[`allowUnique`](#allowUnique) | `Boolean` | `true` | Boolean value to control whether tags should be unqiue
 |[`allowDragDrop`](#allowDragDrop) | `Boolean` | `true` | Boolean value to control whether tags should have drag-n-drop features enabled
-|[`renderSuggestion`](#renderSuggestion) | `Function` | `undefined` | Function that returns a custom suggestion for overriding the default one
+|[`renderSuggestion`](#renderSuggestion) | `Function` | `undefined` | Render prop for rendering your own suggestions
 
 <a name="tagsOption"></a>
 ##### tags (optional, defaults to `[]`)

--- a/__tests__/suggestions.test.js
+++ b/__tests__/suggestions.test.js
@@ -206,4 +206,14 @@ describe('Suggestions', function() {
 
     expect($el.componentDidUpdate.called).to.equal(true);
   });
+
+  test('should render custom suggestions', function() {
+    const $el = shallow(
+      mockItem({
+        customSuggestion: ({ text }) => <div><i />{text}</div>,
+      })
+    );
+
+    expect($el.find('i').length).to.equal(4);
+  });
 });

--- a/__tests__/suggestions.test.js
+++ b/__tests__/suggestions.test.js
@@ -210,7 +210,12 @@ describe('Suggestions', function() {
   test('should render custom suggestions', function() {
     const $el = shallow(
       mockItem({
-        customSuggestion: ({ text }) => <div><i />{text}</div>,
+        customSuggestion: ({ text }) => (
+          <div>
+            <i />
+            {text}
+          </div>
+        ),
       })
     );
 

--- a/__tests__/suggestions.test.js
+++ b/__tests__/suggestions.test.js
@@ -207,7 +207,7 @@ describe('Suggestions', function() {
     expect($el.componentDidUpdate.called).to.equal(true);
   });
 
-  test('should render custom suggestions', function() {
+  test('should render custom suggestions when renderSuggestion prop is provided', function() {
     const $el = shallow(
       mockItem({
         renderSuggestion: ({ text }) => (

--- a/__tests__/suggestions.test.js
+++ b/__tests__/suggestions.test.js
@@ -211,7 +211,7 @@ describe('Suggestions', function() {
     const $el = shallow(
       mockItem({
         customSuggestion: ({ text }) => (
-          <div>
+          <div className="bar">
             <i />
             {text}
           </div>
@@ -219,6 +219,6 @@ describe('Suggestions', function() {
       })
     );
 
-    expect($el.find('i').length).to.equal(4);
+    expect($el.find('.bar').length).to.equal(4);
   });
 });

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -61,6 +61,7 @@ class ReactTags extends Component {
       })
     ),
     allowUnique: PropTypes.bool,
+    customSuggestion: PropTypes.func,
   };
 
   static defaultProps = {
@@ -416,6 +417,7 @@ class ReactTags extends Component {
           shouldRenderSuggestions={this.props.shouldRenderSuggestions}
           isFocused={this.state.isFocused}
           classNames={this.state.classNames}
+          customSuggestion={this.props.customSuggestion}
         />
       </div>
     ) : null;

--- a/src/components/Suggestions.js
+++ b/src/components/Suggestions.js
@@ -87,6 +87,10 @@ class Suggestions extends Component {
 
   render() {
     const { props } = this;
+    const suggestion = props.customSuggestion
+      ? props.customSuggestion(item, props.query)
+      : <span dangerouslySetInnerHTML={this.markIt(item, props.query)} />
+
     const suggestions = props.suggestions.map(
       function(item, i) {
         return (
@@ -97,11 +101,7 @@ class Suggestions extends Component {
             className={
               i === props.selectedIndex ? props.classNames.activeSuggestion : ''
             }>
-            {
-              props.customSuggestion
-                ? props.customSuggestion(item, props.query)
-                : <span dangerouslySetInnerHTML={this.markIt(item, props.query)} />
-            }
+            {suggestion}
           </li>
         );
       }.bind(this)

--- a/src/components/Suggestions.js
+++ b/src/components/Suggestions.js
@@ -29,6 +29,7 @@ class Suggestions extends Component {
     isFocused: PropTypes.bool.isRequired,
     classNames: PropTypes.object,
     labelField: PropTypes.string.isRequired,
+    customSuggestion: PropTypes.func,
   };
 
   static defaultProps = {
@@ -96,7 +97,11 @@ class Suggestions extends Component {
             className={
               i === props.selectedIndex ? props.classNames.activeSuggestion : ''
             }>
-            <span dangerouslySetInnerHTML={this.markIt(item, props.query)} />
+            {
+              props.customSuggestion
+                ? props.customSuggestion(item, props.query)
+                : <span dangerouslySetInnerHTML={this.markIt(item, props.query)} />
+            }
           </li>
         );
       }.bind(this)

--- a/src/components/Suggestions.js
+++ b/src/components/Suggestions.js
@@ -85,11 +85,15 @@ class Suggestions extends Component {
     return query.length >= minQueryLength && isFocused;
   };
 
+  renderSuggestion = (item, query) => {
+    if (this.props.customSuggestion) {
+      return this.props.customSuggestion(item, query);
+    }
+    return <span dangerouslySetInnerHTML={this.markIt(item, query)} />
+  };
+
   render() {
     const { props } = this;
-    const suggestion = props.customSuggestion
-      ? props.customSuggestion(item, props.query)
-      : <span dangerouslySetInnerHTML={this.markIt(item, props.query)} />
 
     const suggestions = props.suggestions.map(
       function(item, i) {
@@ -101,7 +105,7 @@ class Suggestions extends Component {
             className={
               i === props.selectedIndex ? props.classNames.activeSuggestion : ''
             }>
-            {suggestion}
+            {this.renderSuggestion(item, props.query)}
           </li>
         );
       }.bind(this)

--- a/src/components/Suggestions.js
+++ b/src/components/Suggestions.js
@@ -86,8 +86,9 @@ class Suggestions extends Component {
   };
 
   renderSuggestion = (item, query) => {
-    if (this.props.renderSuggestion) {
-      return this.props.renderSuggestion(item, query);
+    const { renderSuggestion } = this.props;
+    if (typeof renderSuggestion === 'function') {
+      return renderSuggestion(item, query);
     }
     return <span dangerouslySetInnerHTML={this.markIt(item, query)} />;
   };

--- a/src/components/Suggestions.js
+++ b/src/components/Suggestions.js
@@ -89,7 +89,7 @@ class Suggestions extends Component {
     if (this.props.customSuggestion) {
       return this.props.customSuggestion(item, query);
     }
-    return <span dangerouslySetInnerHTML={this.markIt(item, query)} />
+    return <span dangerouslySetInnerHTML={this.markIt(item, query)} />;
   };
 
   render() {


### PR DESCRIPTION
This feature allows to pass a default functional component as a prop and override default suggestion component. I wrote it because I need it for my own project, in order to show different icons based on the type of suggestion. I would be glad if you reviewed it and considered adding this feature to your library so that anyone can use it. I would also be glad to receive some feedback, as I have no experience contributing to open source libraries.
Thanks!