### PR TITLE
Fixes Issue #486 - length should be equal to 1 to pick first tag

### DIFF
--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -316,7 +316,7 @@ class ReactTags extends Component {
 
       if (
         (this.props.autocomplete === 1 && possibleMatches.length === 1) ||
-        (this.props.autocomplete === true && possibleMatches.length)
+        (this.props.autocomplete === true && possibleMatches.length === 1)
       ) {
         tag = possibleMatches[0];
       }

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -315,8 +315,7 @@ class ReactTags extends Component {
       );
 
       if (
-        (this.props.autocomplete === 1 && possibleMatches.length === 1) ||
-        (this.props.autocomplete === true && possibleMatches.length === 1)
+        this.props.autocomplete && possibleMatches.length === 1
       ) {
         tag = possibleMatches[0];
       }


### PR DESCRIPTION
Fixes what I assume to be a typo.  Whether the value of `autocomplete` is equal to `1` or `true`, we should only default to the first element if there is only one element.  `1` vs `true` should not change this behavior.

fixes https://github.com/prakhar1989/react-tags/issues/486