### PR TITLE
Filter out duplicated tags

### DIFF
--- a/__tests__/reactTags.test.js
+++ b/__tests__/reactTags.test.js
@@ -439,7 +439,6 @@ describe('Test ReactTags', () => {
 
       $input.simulate('change', { target: { value: 'ap' } });
       expect(ReactTagsInstance.state.suggestions).to.have.deep.members([
-        { id: 'Apple', text: 'Apple' },
         { id: 'Apricot', text: 'Apricot' },
       ]);
     });

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -141,11 +141,14 @@ class ReactTags extends Component {
       return this.props.handleFilterSuggestions(query, suggestions);
     }
 
+    const { tags, allowUnique } = this.props;
+    const isTagUnique = (item) =>
+      !(allowUnique && tags.some(tag => tag.id === item.id));
     const exactSuggestions = suggestions.filter((item) => {
-      return this.getQueryIndex(query, item) === 0;
+      return this.getQueryIndex(query, item) === 0 && isTagUnique(item);
     });
     const partialSuggestions = suggestions.filter((item) => {
-      return this.getQueryIndex(query, item) > 0;
+      return this.getQueryIndex(query, item) > 0 && isTagUnique(item);
     });
     return exactSuggestions.concat(partialSuggestions);
   }

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -141,16 +141,20 @@ class ReactTags extends Component {
       return this.props.handleFilterSuggestions(query, suggestions);
     }
 
-    const { tags, allowUnique } = this.props;
-    const isTagUnique = (item) =>
-      !(allowUnique && tags.some(tag => tag.id === item.id));
     const exactSuggestions = suggestions.filter((item) => {
-      return this.getQueryIndex(query, item) === 0 && isTagUnique(item);
+      return this.getQueryIndex(query, item) === 0;
     });
     const partialSuggestions = suggestions.filter((item) => {
-      return this.getQueryIndex(query, item) > 0 && isTagUnique(item);
+      return this.getQueryIndex(query, item) > 0;
     });
-    return exactSuggestions.concat(partialSuggestions);
+    let totalSuggestions = exactSuggestions.concat(partialSuggestions);
+    const { tags, allowUnique } = this.props;
+    if (allowUnique) {
+      totalSuggestions = totalSuggestions.filter((item) =>
+        !tags.some(tag => tag.id === item.id)
+      );
+    }
+    return totalSuggestions;
   }
 
   getQueryIndex = (query, item) => {


### PR DESCRIPTION
This PR partly covers issue #488 and #484 .
It does not provide suggestion list automatically update.
It provides filtering out already selected tags from suggestions depend on `allowUnique` property.
Tests:
At this moment default filter test case with query 'ap' doesn't expect 'apple' because it already in tags list.