### PR TITLE
Allow use of custom input component through inputComponent config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Option | Type | Default | Description
 |[`handleInputFocus`](#handleInputFocus) | `Function` | `undefined` | Event handler for input onFocus
 |[`handleInputBlur`](#handleInputBlur) | `Function` | `undefined` | Event handler for input onBlur
 |[`minQueryLength`](#minQueryLength) | `Number` | `2` | How many characters are needed for suggestions to appear
-|[`removeComponent`](#removeComponent) | `Boolean` | `false` | Custom delete/remove tag element
+|[`inputComponent`](#inputComponent) | `Component` | `'input'` | Custom input component
+|[`removeComponent`](#removeComponent) | `Component` | `'a'` | Custom delete/remove tag element
 |[`autocomplete`](#autocomplete) | `Boolean`/`Number` | `false` | Ensure the first matching suggestion is automatically converted to a tag when a [delimiter](#delimiters) key is pressed
 |[`readOnly`](#readOnly) | `Boolean` | `false` | Read-only mode without the input box and `removeComponent` and drag-n-drop features disabled
 |[`name`](#nameOption) | `String` | `undefined` | The `name` attribute added to the input
@@ -352,6 +353,37 @@ Optional event handler for input onBlur
 ##### minQueryLength (optional, defaults to `2`)
 How many characters are needed for suggestions to appear.
 
+<a name="inputComponent"></a>
+##### inputComponent (optional)
+Provide a custom input component. Handy when using ReactTags together with a react UI framework such as Material UI. Example usage:
+
+```js
+<ReactTags
+    inputComponent={(props) => <TextField fullWidth {...props} />}
+    ...>
+```
+
+```javascript
+import {WithContext as ReactTags} from 'react-tag-input'
+import {TextField} from '@material-ui/core';
+
+class Foo extends React.Component {
+   render() {
+      return <ReactTags inputComponent={InputComponent}/>
+   }
+}
+
+class InputComponent extends React.Component {
+   render() {
+      return (
+        <TextField {...this.props} />
+      )
+   }
+}
+```
+
+The "ReactTags__remove" className and `onClick` handler properties can be automatically included on the `<button>` by using the [JSX spread attribute](https://facebook.github.io/react/docs/jsx-spread.html), as illustrated above.
+
 <a name="removeComponent"></a>
 ##### removeComponent (optional)
 If you'd like to supply your own tag delete/remove element, create a React component and pass it as a property to ReactTags using the `removeComponent` option. By default, a simple anchor link with an "x" text node as its only child is rendered, but if you'd like to, say, replace this with a `<button>` element that uses an image instead of text, your markup may look something like this:
@@ -390,7 +422,7 @@ This option has no effect if there are no [`suggestions`](#suggestionsOption).
 
 <a name="readOnly"></a>
 ##### readOnly (optional, defaults to `false`)
-Renders the component in read-only mode without the input box and `removeComponent`. This also disables the drag-n-drop feature.
+Renders the component in read-only mode without the `inputComponent` and `removeComponent`. This also disables the drag-n-drop feature.
 
 <a name="nameOption"></a>
 ##### name (optional)

--- a/src/components/InputComponent.js
+++ b/src/components/InputComponent.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class InputComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputRef = React.createRef();
+  }
+  componentDidUpdate() {
+    const el = this.inputRef.current;
+    if(this.props.focus && el) {
+      el.focus();
+    } else if(!this.props.focus && el) {
+      el.blur();
+    }
+  }
+  render() {
+    const { inputComponent, focus, ...other } = this.props;
+    if (inputComponent) {
+      const Component = inputComponent;
+      return <Component autoFocus={focus} {...other} />;
+    }
+    return (
+      <input
+        ref={this.inputRef}
+        {...other}
+      />
+    );
+  }
+};
+
+InputComponent.propTypes = {
+  inputComponent: PropTypes.func,
+  focus: PropTypes.bool
+};
+
+export default InputComponent;

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import ClassNames from 'classnames';
 import memoizeOne from 'memoize-one';
 import Tag from './Tag';
+import InputComponent from './InputComponent';
 
 import { buildRegExpFromDelimiters } from './utils';
 
@@ -55,6 +56,7 @@ class ReactTags extends Component {
     minQueryLength: PropTypes.number,
     shouldRenderSuggestions: PropTypes.func,
     removeComponent: PropTypes.func,
+    inputComponent: PropTypes.func,
     autocomplete: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
     readOnly: PropTypes.bool,
     classNames: PropTypes.object,
@@ -104,8 +106,9 @@ class ReactTags extends Component {
     const { suggestions, classNames } = props;
     this.state = {
       suggestions,
-      query: '',
+      query: props.inputValue || '',
       isFocused: false,
+      shouldFocus: false,
       selectedIndex: -1,
       selectionMode: false,
       classNames: { ...DEFAULT_CLASSNAMES, ...classNames },
@@ -156,18 +159,21 @@ class ReactTags extends Component {
       .indexOf(query.toLowerCase());
   }
 
+  focusInput() {
+    this.setState({shouldFocus: true})
+  }
+
   resetAndFocusInput() {
-    this.setState({ query: '' });
-    if (this.textInput) {
-      this.textInput.value = '';
-      this.textInput.focus();
-    }
+    this.setState({
+      query: ''
+    });
+    this.focusInput();
   }
 
   handleDelete(i, e) {
     this.props.handleDelete(i, e);
     if (!this.props.resetInputOnDelete) {
-      this.textInput && this.textInput.focus();
+      this.focusInput();
     } else {
       this.resetAndFocusInput();
     }
@@ -179,7 +185,7 @@ class ReactTags extends Component {
       this.props.handleTagClick(i, e);
     }
     if (!this.props.resetInputOnDelete) {
-      this.textInput && this.textInput.focus();
+      this.focusInput();
     } else {
       this.resetAndFocusInput();
     }
@@ -210,18 +216,21 @@ class ReactTags extends Component {
     if (this.props.handleInputFocus) {
       this.props.handleInputFocus(value);
     }
-    this.setState({ isFocused: true });
+    this.setState({
+      shouldFocus: true,
+      isFocused: true
+    });
   }
 
   handleBlur(e) {
     const value = e.target.value;
     if (this.props.handleInputBlur) {
       this.props.handleInputBlur(value);
-      if (this.textInput) {
-        this.textInput.value = '';
-      }
     }
-    this.setState({ isFocused: false });
+    this.setState({
+      shouldFocus: false,
+      isFocused: false
+    });
   }
 
   handleKeyDown(e) {
@@ -417,16 +426,16 @@ class ReactTags extends Component {
       maxLength,
       inline,
       inputFieldPosition,
+      inputComponent
     } = this.props;
 
     const position = !inline ? INPUT_FIELD_POSITIONS.BOTTOM : inputFieldPosition;
 
     const tagInput = !this.props.readOnly ? (
       <div className={this.state.classNames.tagInput}>
-        <input
-          ref={(input) => {
-            this.textInput = input;
-          }}
+        <InputComponent
+          inputComponent={inputComponent}
+          focus={this.state.shouldFocus}
           className={this.state.classNames.tagInputField}
           type="text"
           placeholder={placeholder}
@@ -439,7 +448,7 @@ class ReactTags extends Component {
           name={inputName}
           id={inputId}
           maxLength={maxLength}
-          value={this.props.inputValue}
+          value={this.state.query}
         />
 
         <Suggestions


### PR DESCRIPTION
Hi!

This PR adds the config option "inputComponent" which makes it possible to specify a custom component to use instead of the default "input" element. Very useful when using third party UI libraries such as Material UI, where it's common to use a component for text input provided by the library.

I have tested this new feature in my own project and it works well. The "autoFocus" option and the focus events fired by this library required some extra attention to ensure backward compatibility.