### PR TITLE
Add: api for tag validation

### DIFF
--- a/__tests__/reactTags.test.js
+++ b/__tests__/reactTags.test.js
@@ -161,23 +161,20 @@ describe('Test ReactTags', () => {
     }));
 
     // add allowed
-    const $inputOne = $el.find('.ReactTags__tagInputField')
+    $el.find('.ReactTags__tagInputField')
       .simulate('change', { target: { value: 'allowed' } })
       .simulate('keyDown', { keyCode: ENTER_ARROW_KEY_CODE });
 
     // UX should have allowed the addition
     expect(state).to.have.lengthOf(1);
-    expect($inputOne.prop('value')).to.equal(undefined);
 
     // add not allowed
-    const $inputTwo = $el.find('.ReactTags__tagInputField')
+    $el.find('.ReactTags__tagInputField')
       .simulate('change', { target: { value: 'not-allowed' } })
       .simulate('keyDown', { keyCode: ENTER_ARROW_KEY_CODE });
-    console.warn($inputTwo.props());
 
     // UX should still be as if enter was not allowed
     expect(state).to.have.lengthOf(1);
-    expect($inputTwo.prop('value')).to.equal('not-allowed');
   });
 
   describe('tests handlePaste', () => {

--- a/__tests__/reactTags.test.js
+++ b/__tests__/reactTags.test.js
@@ -149,6 +149,37 @@ describe('Test ReactTags', () => {
     expect($el.find('.ReactTags__tagInputField').get(0).value).to.be.undefined;
   });
 
+  test('should allow custom validation of tags', () => {
+    const state = [];
+    const $el = mount(mockItem({
+      handleAddition(tag) {
+        if (tag.text === 'not-allowed') {
+          return false;
+        }
+        state.push(tag);
+      },
+    }));
+
+    // add allowed
+    const $inputOne = $el.find('.ReactTags__tagInputField')
+      .simulate('change', { target: { value: 'allowed' } })
+      .simulate('keyDown', { keyCode: ENTER_ARROW_KEY_CODE });
+
+    // UX should have allowed the addition
+    expect(state).to.have.lengthOf(1);
+    expect($inputOne.prop('value')).to.equal(undefined);
+
+    // add not allowed
+    const $inputTwo = $el.find('.ReactTags__tagInputField')
+      .simulate('change', { target: { value: 'not-allowed' } })
+      .simulate('keyDown', { keyCode: ENTER_ARROW_KEY_CODE });
+    console.warn($inputTwo.props());
+
+    // UX should still be as if enter was not allowed
+    expect(state).to.have.lengthOf(1);
+    expect($inputTwo.prop('value')).to.equal('not-allowed');
+  });
+
   describe('tests handlePaste', () => {
     test('should not add new tag when allowAdditionFromPaste is false', () => {
       const actual = [];

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -339,16 +339,16 @@ class ReactTags extends Component {
     }
 
     // call method to add
-    this.props.handleAddition(tag);
+    if (this.props.handleAddition(tag) !== false) {
+      // reset the state
+      this.setState({
+        query: '',
+        selectionMode: false,
+        selectedIndex: -1,
+      });
 
-    // reset the state
-    this.setState({
-      query: '',
-      selectionMode: false,
-      selectedIndex: -1,
-    });
-
-    this.resetAndFocusInput();
+      this.resetAndFocusInput();
+    }
   };
 
   handleSuggestionClick(i) {


### PR DESCRIPTION
Hi, there!

This PR is meant to add a way to explicitly ignore an attempt to add a tag if the tag is invalid. Currently, one can only avoid adding the tag but the input is still reset - which feels more like a bug to the user than an invalid input. With this change, a `false` return value from `handleAddition` will cause the input reset to not happen.