### PR TITLE
"Clear tags" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ This props allows to provide your own suggestion renderer and override the defau
 - `ReactTags__selected ReactTags__remove`
 - `ReactTags__suggestions`
 - `ReactTags__activeSuggestion`
+- `ReactTags__clearAll`
 
 An example can be found in `/example/reactTags.css`.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ React-tags is a simple tagging component ready to drop in your React projects. T
 - Autocomplete based on a suggestion list
 - Keyboard friendly and mouse support
 - Reorder tags using drag and drop
+- Optional clear all button
 
 ### Why
 Because I was looking for an excuse to build a standalone component and publish it in the wild? To be honest, I needed a tagging component that provided the above features for my [React-Surveyman](http://github.com/prakhar1989/react-surveyman) project. Since I was unable to find one which met my requirements (and the fact that I generally enjoy re-inventing the wheel) this is what I came up with.
@@ -164,6 +165,8 @@ Option | Type | Default | Description
 |[`allowUnique`](#allowUnique) | `Boolean` | `true` | Boolean value to control whether tags should be unqiue
 |[`allowDragDrop`](#allowDragDrop) | `Boolean` | `true` | Boolean value to control whether tags should have drag-n-drop features enabled
 |[`renderSuggestion`](#renderSuggestion) | `Function` | `undefined` | Render prop for rendering your own suggestions
+|[`allowClearAll`](#allowClearAll) | `Boolean` | `false` | Boolean value to control whether 'clear tags' button should be visible
+|[`handleClearAll`](#handleClearAll) | `Function` | `undefined` | Event handler for 'clear tags' button click
 
 <a name="tagsOption"></a>
 ##### tags (optional, defaults to `[]`)
@@ -490,6 +493,14 @@ This props allows to provide your own suggestion renderer and override the defau
     ...>
 ```
 
+<a name="allowClearAll"></a>
+#### allowClearAll (optional)
+This props controls whether 'clear tags' button should be visible or not.
+
+<a name="handleClearAll"></a>
+#### handleClearAll (optional)
+Optional event handler for 'clear tags' button click.
+
 ### Styling
 `<ReactTags>` does not come up with any styles. However, it is very easy to customize the look of the component the way you want it. By default, the component provides the following classes with which you can style -
 
@@ -518,7 +529,8 @@ a `classNames` prop.
       tag: 'tagClass',
       remove: 'removeClass',
       suggestions: 'suggestionsClass',
-      activeSuggestion: 'activeSuggestionClass'
+      activeSuggestion: 'activeSuggestionClass',
+      clearAll: 'clearAllClass',
     }}
     ...>
 ```

--- a/__tests__/reactTags.test.js
+++ b/__tests__/reactTags.test.js
@@ -700,8 +700,12 @@ describe('Test inputFieldPosition', () => {
       })
     );
 
-    expect(consoleWarnStub.calledOnce ).to.be.true;
-    expect(consoleWarnStub.calledWithExactly('[Deprecation] The inline attribute is deprecated and will be removed in v7.x.x, please use inputFieldPosition instead.')).to.be.true;
+    expect(consoleWarnStub.calledOnce).to.be.true;
+    expect(
+      consoleWarnStub.calledWithExactly(
+        '[Deprecation] The inline attribute is deprecated and will be removed in v7.x.x, please use inputFieldPosition instead.'
+      )
+    ).to.be.true;
 
     consoleWarnStub.restore();
   });

--- a/__tests__/reactTags.test.js
+++ b/__tests__/reactTags.test.js
@@ -55,6 +55,8 @@ describe('Test ReactTags', () => {
       allowDragDrop: true,
       ...defaults,
       allowUnique: true,
+      allowClearAll: false,
+      handleClearAll: noop,
     };
     expect($el).to.have.length(1);
     expect($el.props().children.props).to.deep.equal(expectedProps);
@@ -702,5 +704,33 @@ describe('Test inputFieldPosition', () => {
     expect(consoleWarnStub.calledWithExactly('[Deprecation] The inline attribute is deprecated and will be removed in v7.x.x, please use inputFieldPosition instead.')).to.be.true;
 
     consoleWarnStub.restore();
+  });
+
+  test('should not show a clear tags span as default', () => {
+    const $el = mount(mockItem());
+    expect($el.exists('.ReactTags__clearAll')).to.equal(false);
+  });
+
+  test('should show a clear tags span if "allowClearTags" is enabled', () => {
+    const $el = mount(
+      mockItem({
+        allowClearAll: true,
+      })
+    );
+    expect($el.exists('.ReactTags__clearAll')).to.equal(true);
+  });
+
+  test('should invoke "handleClearAll" on clear tags mouse down', () => {
+    const handleClearAll = spy();
+    const $el = mount(
+      mockItem({
+        allowClearAll: true,
+        handleClearAll,
+      })
+    );
+
+    const $clearAll = $el.find('.ReactTags__clearAll');
+    $clearAll.simulate('mousedown');
+    expect(handleClearAll.callCount).to.equal(1);
   });
 });

--- a/example/main.js
+++ b/example/main.js
@@ -248,6 +248,7 @@ class App extends React.Component {
     this.handleAddition = this.handleAddition.bind(this);
     this.handleDrag = this.handleDrag.bind(this);
     this.handleTagClick = this.handleTagClick.bind(this);
+    this.handleClearAll = this.handleClearAll.bind(this);
   }
 
   handleDelete(i) {
@@ -276,6 +277,12 @@ class App extends React.Component {
     console.log('The tag at index ' + index + ' was clicked');
   }
 
+  handleClearAll() {
+    this.setState({
+      tags: [],
+    });
+  }
+
   render() {
     const { tags } = this.state;
     return (
@@ -288,6 +295,8 @@ class App extends React.Component {
           handleAddition={this.handleAddition}
           handleDrag={this.handleDrag}
           handleTagClick={this.handleTagClick}
+          allowClearAll
+          handleClearAll={this.handleClearAll}
         />
       </div>
     );

--- a/example/reactTags.css
+++ b/example/reactTags.css
@@ -3,6 +3,13 @@ div.ReactTags__tags {
     position: relative;
 }
 
+/* Styles for the clear tags span */
+span.ReactTags__clearAll {
+    text-decoration: underline;
+    color: blue;
+    cursor: pointer;
+}
+
 /* Styles for the input */
 div.ReactTags__tagInput {
     width: 200px;

--- a/src/components/ClearAllTags.js
+++ b/src/components/ClearAllTags.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class ClearAllTags extends Component {
+  static propTypes = {
+    classNames: PropTypes.object,
+    handleClick: PropTypes.func,
+  };
+
+  render() {
+    const { props } = this;
+    return (
+      <span className={this.props.classNames.clearAll} onMouseDown={props.handleClick}>clear tags</span>
+    );
+  }
+}
+
+export default ClearAllTags;

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -3,6 +3,7 @@ import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import noop from 'lodash/noop';
 import uniq from 'lodash/uniq';
+import ClearAllTags from './ClearAllTags';
 import Suggestions from './Suggestions';
 import PropTypes from 'prop-types';
 import ClassNames from 'classnames';
@@ -70,6 +71,8 @@ class ReactTags extends Component {
     ),
     allowUnique: PropTypes.bool,
     renderSuggestion: PropTypes.func,
+    allowClearAll: PropTypes.bool,
+    handleClearAll: PropTypes.func,
   };
 
   static defaultProps = {
@@ -90,6 +93,8 @@ class ReactTags extends Component {
     allowUnique: true,
     allowDragDrop: true,
     tags: [],
+    allowClearAll: true,
+    handleClearAll: noop,
   };
 
   constructor(props) {
@@ -120,6 +125,7 @@ class ReactTags extends Component {
     this.resetAndFocusInput = this.resetAndFocusInput.bind(this);
     this.handleSuggestionHover = this.handleSuggestionHover.bind(this);
     this.handleSuggestionClick = this.handleSuggestionClick.bind(this);
+    this.handleClearAllClick = this.handleClearAllClick.bind(this);
 
   }
 
@@ -355,6 +361,12 @@ class ReactTags extends Component {
     this.addTag(this.state.suggestions[i]);
   }
 
+  handleClearAllClick() {
+    if (this.props.handleClearAll) {
+      this.props.handleClearAll();
+    }
+  }
+
   handleSuggestionHover(i) {
     this.setState({
       selectedIndex: i,
@@ -417,6 +429,8 @@ class ReactTags extends Component {
       maxLength,
       inline,
       inputFieldPosition,
+      allowClearAll,
+      tags,
     } = this.props;
 
     const position = !inline ? INPUT_FIELD_POSITIONS.BOTTOM : inputFieldPosition;
@@ -460,6 +474,9 @@ class ReactTags extends Component {
 
     return (
       <div className={ClassNames(this.state.classNames.tags, 'react-tags-wrapper')}>
+        {allowClearAll && tags.length > 0 && (
+          <ClearAllTags classNames={this.state.classNames} handleClick={this.handleClearAllClick} />
+        )}
         {position === INPUT_FIELD_POSITIONS.TOP && tagInput}
         <div className={this.state.classNames.selected}>
           {tagItems}

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -93,7 +93,7 @@ class ReactTags extends Component {
     allowUnique: true,
     allowDragDrop: true,
     tags: [],
-    allowClearAll: true,
+    allowClearAll: false,
     handleClearAll: noop,
   };
 

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -20,6 +20,7 @@ export const DEFAULT_CLASSNAMES = {
   remove: 'ReactTags__remove',
   suggestions: 'ReactTags__suggestions',
   activeSuggestion: 'ReactTags__activeSuggestion',
+  clearAll: 'ReactTags__clearAll',
 };
 
 export const INPUT_FIELD_POSITIONS = {


### PR DESCRIPTION
Added a new "Clear tags" functionality for delete all tags.

I added 2 optional props:
`allowClearAll` manages button visibility
`handleClearAll` is the event handler for the button

I also wrote some tests and docs :)