### PR TITLE
fix(ReactTags): drag and drop not working

### DIFF
--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -387,7 +387,7 @@ class ReactTags extends Component {
     return tags.map((tag, index) => {
       return (
         <Tag
-          key={`${tag.id}-${index}`}
+          key={tag.key || tag.id}
           index={index}
           tag={tag}
           labelField={labelField}

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -54,6 +54,7 @@ Tag.propTypes = {
   tag: PropTypes.shape({
     id: PropTypes.string.isRequired,
     className: PropTypes.string,
+    key: PropTypes.string,
   }),
   moveTag: PropTypes.func,
   removeComponent: PropTypes.func,


### PR DESCRIPTION
As mentioned in an issue, #559, if you drag and drop, React DND throws an invariant issue.

This change makes it so if you pass in a third property to each of your tags, you can have drag and drop. 

I haven't tested any other usecases beyond mine though, so if anyone else wanted to confirm this works for them, that would be appreciated. Meanwhile, the change can be made in your local `node_modules\react-tag-input\dist-modules\components\ReactTags.js#523`