### PR TITLE
fix(ReactTags): Fix delete error when tags are empty

### DIFF
--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -164,13 +164,11 @@ class ReactTags extends Component {
     event.preventDefault();
     event.stopPropagation();
     const currentTags = this.props.tags.slice();
-    
-    // Early exit from the function if the array 
+    // Early exit from the function if the array
     // is already empty
     if (currentTags.length === 0) {
       return;
     }
-    
     let ariaLiveStatus = `Tag at index ${index} with value ${currentTags[index].id} deleted.`;
     this.props.handleDelete(index, event);
     const allTags = this.reactTagsRef.current.querySelectorAll(

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -164,6 +164,13 @@ class ReactTags extends Component {
     event.preventDefault();
     event.stopPropagation();
     const currentTags = this.props.tags.slice();
+    
+    // Early exit from the function if the array 
+    // is already empty
+    if (currentTags.length === 0) {
+      return;
+    }
+    
     let ariaLiveStatus = `Tag at index ${index} with value ${currentTags[index].id} deleted.`;
     this.props.handleDelete(index, event);
     const allTags = this.reactTagsRef.current.querySelectorAll(


### PR DESCRIPTION
When there are no tags left and the user tries to delete tags, we get this error for the line, because the value of `currentTags[index]` will be `undefined`
https://github.com/prakhar1989/react-tags/blob/19faa054bf33e9d355e8f31e7558ccd92c981056/src/components/ReactTags.js#L167

![Image 2021-02-12 at 9 37 30 PM](https://user-images.githubusercontent.com/21277179/107792361-0f4c5d80-6d7b-11eb-977c-c7742304ebf6.jpg)

I have added any early return from the `handleDelete` function to avoid this error
